### PR TITLE
Change path of gh-pages folder to deploy documentation on GitHub

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,7 +31,6 @@ jobs:
         cd $GITHUB_WORKSPACE
         pdoc -o docs emcpy
         ls -lR docs/
-        echo "$GITHUB_WORKSPACE/docs"
 
     - name: Deploy documentation
       uses: JamesIves/github-pages-deploy-action@4.1.4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,10 +31,11 @@ jobs:
         cd $GITHUB_WORKSPACE
         pdoc -o docs emcpy
         ls -lR docs/
+        echo "$GITHUB_WORKSPACE/docs"
 
     - name: Deploy documentation
       uses: JamesIves/github-pages-deploy-action@4.1.4
       with:
         branch: gh-pages
-        folder: $GITHUB_WORKSPACE/docs
+        folder: docs
 


### PR DESCRIPTION
The GitHub action to build documentation was failing on develop with an error about a path not existing, this change is an attempt to fix this error.