### PR TITLE
Add __init__.py so that one can import emcpy.plots.scatter()

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
   netcdf4
   scikit-learn
   pdoc
+  matplotlib
 tests_require =
   pytest
 

--- a/src/emcpy/__init__.py
+++ b/src/emcpy/__init__.py
@@ -2,3 +2,4 @@ import emcpy.calcs
 import emcpy.utils
 import emcpy.stats
 import emcpy.io.netCDF
+import emcpy.plots

--- a/src/emcpy/plots/__init__.py
+++ b/src/emcpy/plots/__init__.py
@@ -1,0 +1,1 @@
+from .scatter import scatter


### PR DESCRIPTION
This PR adds:
`import emcpy.plots` to the top level `__init__.py`
and
a new `__init__.py` to the plots directory so that instead of doing
`emcpy.plots.scatter.scatter()`
we can call it with `emcpy.plots.scatter()`