### PR TITLE
Bugfix for linear regression plot option

### DIFF
--- a/src/emcpy/plots/scatter.py
+++ b/src/emcpy/plots/scatter.py
@@ -94,7 +94,7 @@ def scatter(x, y, linear_regression=True, density=False,
         Figure of the scatter plot
     """
 
-    plotopts = {'linear regression': linear_regression, 'density': density,
+    plotopts = {'linear_regression': linear_regression, 'density': density,
                 'color': color, 'cmap': cmap, 'r color': r_color,
                 'grid': grid, 'title': title, 'time title': time_title,
                 'xlabel': xlabel, 'ylabel': ylabel}


### PR DESCRIPTION
The scatter plot failed to run because the key should be `linear_regression` and not `linear regression`. Fixing this.