### PR TITLE
Add datatypes to docstrings; reformat scatter.py doc

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Generate documentation
       run: |
-        pdoc -o docs emcpy
+        pdoc --docformat "google" -o docs emcpy
         ls -lR docs/
 
     - name: Deploy documentation
@@ -33,4 +33,3 @@ jobs:
       with:
         branch: gh-pages
         folder: docs
-

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,5 +32,11 @@ jobs:
     - name: Generate documentation
       run: |
         cd $GITHUB_WORKSPACE
-        pdoc -o docs emcpy
+        pdoc --docformat "google" -o docs emcpy
         ls -lR docs/
+
+    - name: Upload documentation
+      uses: actions/upload-artifact@v2
+      with:
+        name: docs
+        path: docs

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ Documentation is automatically generated when `develop` is updated and available
 
 To manually generate documentation upon installation (requires [`pdoc`](https://pdoc.dev/)):
 ```sh
-$> pdoc emcpy
+$> pdoc --docformat "google" emcpy
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ $> pip install .
 ```
 
 ### Documentation
-Documentation is automatically generated when `develop` is updated and available [here](https://noaa-emc.github.io/emcpy).
+Documentation is automatically generated when `develop` is updated and available [here](https://noaa-emc.github.io/emcpy/emcpy.html).
 
 To manually generate documentation upon installation (requires [`pdoc`](https://pdoc.dev/)):
 ```sh

--- a/src/emcpy/README.md
+++ b/src/emcpy/README.md
@@ -1,0 +1,11 @@
+EMCPy
+-----
+A comprehensive python toolkit for EMC developers and collaborators.
+
+
+Currently contains the following submodules:
+- emcpy.calcs : computations, such as unit conversions, wind speed/direction from u,v vectors, etc.\n
+- emcpy.io : helper routines to aid in read/write of various formats\n
+- emcpy.plots : common plotting routines for scatter, line, map plots, etc.\n
+- emcpy.stats : functions to compute various statistics\n
+- emcpy.utils : miscellaneous utility functions\n

--- a/src/emcpy/__init__.py
+++ b/src/emcpy/__init__.py
@@ -1,19 +1,10 @@
+"""
+.. include:: ./README.md
+"""
+__docformat__ = "restructuredtext"
+
 import emcpy.calcs
 import emcpy.utils
 import emcpy.stats
 import emcpy.io.netCDF
 import emcpy.plots
-
-"""
-EMCPy
------
-A comprehensive python toolkit for EMC developers and collaborators
-
-Currently contains the following submodules
-    emcpy.calcs : computations, such as unit conversions, wind speed/direction from u,v vectors, etc.
-    emcpy.io : helper routines to aid in read/write of various formats
-    emcpy.plots : common plotting routines for scatter, line, map plots, etc.
-    emcpy.stats : functions to compute various statistics
-    emcpy.utils : miscellaneous utility functions
-
-"""

--- a/src/emcpy/calcs/units.py
+++ b/src/emcpy/calcs/units.py
@@ -7,12 +7,10 @@ def K_to_C(K):
     """
     Convert Kelvin to Celsius
 
-    Parameters
-    ----------
+    Args:
         K : (float, or array of floats) temperature in kelvin
-    Returns
-    -------
-        C : (float, or array of floats) temperature in degrees celsius
+    Returns:
+        The input temperature in degrees celsius
     """
     return K - 273.15
 
@@ -21,12 +19,10 @@ def K_to_F(K):
     """
     Convert Kelvin to Fahrenheit
 
-    Parameters
-    ----------
+    Args:
         K : (float, or array of floats) temperature in kelvin
-    Returns
-    -------
-        F : (float, or array of floats) temperature in degrees fahrenheit
+    Returns:
+        The input temperature in degrees fahrenheit
     """
     return (K-273.15)*9/5.+32
 
@@ -35,12 +31,10 @@ def C_to_K(T_C):
     """
     Convert Celsius to Kelvin
 
-    Parameters
-    ----------
+    Args:
         T_C : (float, or array of floats) temperature in degrees celsius
-    Returns
-    -------
-        K : (float, or array of floats) temperature in kelvin
+    Returns:
+        The input temperature in kelvin
     """
     return T_C + 273.15
 
@@ -49,12 +43,10 @@ def C_to_F(C):
     """
     Convert Celsius to Fahrenheit
 
-    Parameters
-    ----------
+    Args:
         C : (float, or array of floats) temperature in degrees celsius
-    Returns
-    -------
-        F : (float, or array of floats) temperature in degrees fahrenheit
+    Returns:
+        The input temperature in degrees fahrenheit
     """
     return C*9/5.+32
 
@@ -63,12 +55,10 @@ def F_to_C(F):
     """
     Convert Fahrenheit to Celsius
 
-    Parameters
-    ----------
+    Args:
         F : (float, or array of floats) temperature in degrees fahrenheit
-    Returns
-    -------
-        C : (float, or array of floats) temperature in degrees celsius
+    Returns:
+        The input temperature in degrees celsius
     """
     return (F-32) * 5/9
 
@@ -78,12 +68,10 @@ def mps_to_MPH(mps):
     """
     Convert meters per second to miles per hour
 
-    Parameters
-    ----------
+    Args:
         mps : (float, or array of floats) speed in meters per second
-    Returns
-    -------
-        MPH : (float, or array of floats) speed in miles per hour
+    Returns:
+        The input speed in miles per hour
     """
     return mps * 2.2369
 
@@ -92,12 +80,10 @@ def MPH_to_mps(MPH):
     """
     Convert miles per hour to meters per second
 
-    Parameters
-    ----------
+    Args:
         MPH : (float, or array of floats) speed in miles per hour
-    Returns
-    -------
-        mps : (float, or array of floats) speed in meters per second
+    Returns:
+        The input speed in meters per second
     """
     return MPH / 2.2369
 
@@ -107,12 +93,10 @@ def mm_to_inches(mm):
     """
     Convert millimeters to inches
 
-    Parameters
-    ----------
+    Args:
         mm : (float, or array of floats) length in millimeters
-    Returns
-    -------
-        inches : (float, or array of floats) length in inches
+    Returns:
+        The input length in inches
     """
     return mm * 0.0394
 
@@ -121,11 +105,9 @@ def inches_to_mm(inches):
     """
     Convert inches to millimeters
 
-    Parameters
-    ----------
+    Args:
         inches : (float, or array of floats) length in inches
-    Returns
-    -------
-        mm : (float, or array of floats) length in millimeters
+    Returns:
+        The input length in millimeters
     """
     return inches / 0.0394

--- a/src/emcpy/calcs/units.py
+++ b/src/emcpy/calcs/units.py
@@ -9,10 +9,10 @@ def K_to_C(K):
 
     Parameters
     ----------
-        K : temperature in kelvin
+        K : (float, or array of floats) temperature in kelvin
     Returns
     -------
-        C : temperature in degrees celsius
+        C : (float, or array of floats) temperature in degrees celsius
     """
     return K - 273.15
 
@@ -23,10 +23,10 @@ def K_to_F(K):
 
     Parameters
     ----------
-        K : temperature in kelvin
+        K : (float, or array of floats) temperature in kelvin
     Returns
     -------
-        F : temperature in degrees fahrenheit
+        F : (float, or array of floats) temperature in degrees fahrenheit
     """
     return (K-273.15)*9/5.+32
 
@@ -37,10 +37,10 @@ def C_to_K(T_C):
 
     Parameters
     ----------
-        T_C : temperature in degrees celsius
+        T_C : (float, or array of floats) temperature in degrees celsius
     Returns
     -------
-        K : temperature in kelvin
+        K : (float, or array of floats) temperature in kelvin
     """
     return T_C + 273.15
 
@@ -51,10 +51,10 @@ def C_to_F(C):
 
     Parameters
     ----------
-        C : temperature in degrees celsius
+        C : (float, or array of floats) temperature in degrees celsius
     Returns
     -------
-        F : temperature in degrees fahrenheit
+        F : (float, or array of floats) temperature in degrees fahrenheit
     """
     return C*9/5.+32
 
@@ -65,10 +65,10 @@ def F_to_C(F):
 
     Parameters
     ----------
-        F : temperature in degrees fahrenheit
+        F : (float, or array of floats) temperature in degrees fahrenheit
     Returns
     -------
-        C : temperature in degrees celsius
+        C : (float, or array of floats) temperature in degrees celsius
     """
     return (F-32) * 5/9
 
@@ -80,10 +80,10 @@ def mps_to_MPH(mps):
 
     Parameters
     ----------
-        mps : speed in meters per second
+        mps : (float, or array of floats) speed in meters per second
     Returns
     -------
-        MPH : speed in miles per hour
+        MPH : (float, or array of floats) speed in miles per hour
     """
     return mps * 2.2369
 
@@ -94,10 +94,10 @@ def MPH_to_mps(MPH):
 
     Parameters
     ----------
-        MPH : speed in miles per hour
+        MPH : (float, or array of floats) speed in miles per hour
     Returns
     -------
-        mps : speed in meters per second
+        mps : (float, or array of floats) speed in meters per second
     """
     return MPH / 2.2369
 
@@ -109,10 +109,10 @@ def mm_to_inches(mm):
 
     Parameters
     ----------
-        mm : length in millimeters
+        mm : (float, or array of floats) length in millimeters
     Returns
     -------
-        inches : length in inches
+        inches : (float, or array of floats) length in inches
     """
     return mm * 0.0394
 
@@ -123,9 +123,9 @@ def inches_to_mm(inches):
 
     Parameters
     ----------
-        inches : length in inches
+        inches : (float, or array of floats) length in inches
     Returns
     -------
-        mm : length in millimeters
+        mm : (float, or array of floats) length in millimeters
     """
     return inches / 0.0394

--- a/src/emcpy/calcs/wind.py
+++ b/src/emcpy/calcs/wind.py
@@ -11,15 +11,12 @@ def uv_to_spddir(u, v, direction=False):
     Takes into account the wind direction coordinates is different than
     the trig unit circle coordinate. If the wind direction is 360,
     then return zero.
-    Parameters
-    ----------
+    Args:
         u : (array like) u (easterly) wind component
         v : (array like) v (northerly) wind component
         direction: (bool, optional, default=False)
-    Returns
-    -------
-        wspd: (numpy array) wind speed
-        wdir: (numpy array) wind direction (if direction=True)
+    Returns:
+        An array of wind speed (and an array of wind direction if direction=True)
     """
     u = np.array(u)
     v = np.array(v)
@@ -33,14 +30,11 @@ def uv_to_spddir(u, v, direction=False):
 def spddir_to_uv(wspd, wdir):
     """
     Calculate the u and v wind components from wind speed and direction.
-    Parameters
-    ----------
+    Args:
         wspd : (array like) wind speed
         wdir : (array like) wind direction in degrees
-    Returns
-    -------
-        u : (numpy array) eastward wind component
-        v : (numpy array) northward wind component
+    Returns:
+        The u,v wind vector components.
     """
     wspd = np.array(wspd, dtype=float)
     wdir = np.array(wdir, dtype=float)

--- a/src/emcpy/calcs/wind.py
+++ b/src/emcpy/calcs/wind.py
@@ -13,12 +13,13 @@ def uv_to_spddir(u, v, direction=False):
     then return zero.
     Parameters
     ----------
-        u, v: array_like
-        u (easterly) and v (northerly) wind component.
-        direction: boolean (optional)
+        u : (array like) u (easterly) wind component
+        v : (array like) v (northerly) wind component
+        direction: (bool, optional, default=False)
     Returns
     -------
-        Wind speed (and direction if direction=True)
+        wspd: (numpy array) wind speed
+        wdir: (numpy array) wind direction (if direction=True)
     """
     u = np.array(u)
     v = np.array(v)
@@ -34,11 +35,12 @@ def spddir_to_uv(wspd, wdir):
     Calculate the u and v wind components from wind speed and direction.
     Parameters
     ----------
-        wspd, wdir : array_like
-        Arrays of wind speed and wind direction (in degrees)
+        wspd : (array like) wind speed
+        wdir : (array like) wind direction in degrees
     Returns
     -------
-        u and v wind components
+        u : (numpy array) eastward wind component
+        v : (numpy array) northward wind component
     """
     wspd = np.array(wspd, dtype=float)
     wdir = np.array(wdir, dtype=float)

--- a/src/emcpy/io/netCDF.py
+++ b/src/emcpy/io/netCDF.py
@@ -14,13 +14,11 @@ def variable_exist(filename, variable_name):
     '''
     Check if a variable exists in a netCDF file
 
-    Parameters
-    ----------
+    Args:
         filename : (str) netCDF filename
         variable_name : (str) variable name to check within filename
-    Returns
-    -------
-        result : (bool) True or False if variable is present
+    Returns:
+        True or False if variable is present
     '''
 
     result = False
@@ -45,16 +43,14 @@ def read_netCDF_var(filename, variable_name, oneD=False, ftime=-1, flevel=-1):
     '''
     Read a variable from a netCDF file
 
-    Parameters
-    ----------
+    Args:
         filename : (str) netCDF filename
         variable_name : (str) variable name to check within filename
         oneD : (bool, optional, default=False) Is variable_name a one-dimensional variable?
         ftime : (int, optional, default=-1) time index range to retrieve data for
         flevel : (int, optional, default=-1) level index range to retrieve data for
-    Returns
-    -------
-        result : (array like) data for variable_name
+    Returns:
+        An array of data for variable_name
     '''
     try:
         nc = _Dataset(filename, 'r')

--- a/src/emcpy/io/netCDF.py
+++ b/src/emcpy/io/netCDF.py
@@ -16,11 +16,11 @@ def variable_exist(filename, variable_name):
 
     Parameters
     ----------
-        filename : netCDF filename
-        variable_name : variable name to check within filename
+        filename : (str) netCDF filename
+        variable_name : (str) variable name to check within filename
     Returns
     -------
-        result : True or False if variable is present
+        result : (bool) True or False if variable is present
     '''
 
     result = False
@@ -47,14 +47,14 @@ def read_netCDF_var(filename, variable_name, oneD=False, ftime=-1, flevel=-1):
 
     Parameters
     ----------
-        filename : netCDF filename
-        variable_name : variable name to check within filename
-        oneD : Is variable_name a one-dimensional variable?
-        ftime : time index range to retrieve data for
-        flevel : level index range to retrieve data for
+        filename : (str) netCDF filename
+        variable_name : (str) variable name to check within filename
+        oneD : (bool, optional, default=False) Is variable_name a one-dimensional variable?
+        ftime : (int, optional, default=-1) time index range to retrieve data for
+        flevel : (int, optional, default=-1) level index range to retrieve data for
     Returns
     -------
-        result : data for variable_name
+        result : (array like) data for variable_name
     '''
     try:
         nc = _Dataset(filename, 'r')

--- a/src/emcpy/plots/scatter.py
+++ b/src/emcpy/plots/scatter.py
@@ -63,7 +63,7 @@ def scatter(x, y, linear_regression=True, density=False,
     """
     Returns a figure of a scatter plot given x and y.
 
-    Parameters:
+    Args:
         x, y : (array type) The data required to create scatter plot
         linear_regression : (bool, optional, default=True) To perform a linear regression and plot the line on the figure
         density : (bool, optional, default=False) Plot a density scatter plot
@@ -77,7 +77,8 @@ def scatter(x, y, linear_regression=True, density=False,
         ylabel : (str, optional, default=None) Y label on plot
 
     Returns:
-        fig : (matplotlib figure object) Figure of the scatter plot
+        A matplotlib figure object of the scatter plot
+
     """
 
     plotopts = {'linear_regression': linear_regression, 'density': density,

--- a/src/emcpy/plots/scatter.py
+++ b/src/emcpy/plots/scatter.py
@@ -64,7 +64,6 @@ def scatter(x, y, linear_regression=True, density=False,
     Returns a figure of a scatter plot given x and y.
 
     Parameters
-    ----------
         x, y : (array type) The data required to create scatter plot
         linear_regression : (bool, optional, default=True) To perform a linear regression and plot the line on the figure
         density : (bool, optional, default=False) Plot a density scatter plot
@@ -78,7 +77,6 @@ def scatter(x, y, linear_regression=True, density=False,
         ylabel : (str, optional, default=None) Y label on plot
 
     Returns
-    -------
         fig : (matplotlib figure object) Figure of the scatter plot
     """
 

--- a/src/emcpy/plots/scatter.py
+++ b/src/emcpy/plots/scatter.py
@@ -63,7 +63,7 @@ def scatter(x, y, linear_regression=True, density=False,
     """
     Returns a figure of a scatter plot given x and y.
 
-    Parameters
+    Parameters:
         x, y : (array type) The data required to create scatter plot
         linear_regression : (bool, optional, default=True) To perform a linear regression and plot the line on the figure
         density : (bool, optional, default=False) Plot a density scatter plot
@@ -76,7 +76,7 @@ def scatter(x, y, linear_regression=True, density=False,
         xlabel : (str, optional, default=None) X label on plot
         ylabel : (str, optional, default=None) Y label on plot
 
-    Returns
+    Returns:
         fig : (matplotlib figure object) Figure of the scatter plot
     """
 

--- a/src/emcpy/plots/scatter.py
+++ b/src/emcpy/plots/scatter.py
@@ -65,33 +65,21 @@ def scatter(x, y, linear_regression=True, density=False,
 
     Parameters
     ----------
-    x, y : array type
-        The data required to create scatter plot
-    linear_regression : bool, optional
-        (default is True)
-    density : bool, optional
-        Plot a density scatter plot if True (default is False)
-    color : str, optional
-        Color of scatter plot dots (default is 'darkgray')
-    cmap : str, optional
-        Color map of density scatter plot (default is 'magma')
-    r_color : str, optional
-        Color of regression line (default is 'black')
-    grid : bool, optional
-        Plot grid on scatter plot (default is False)
-    title : str, optional
-        Plot title (default is 'EMCPy Scatter Plot')
-    time_title : str, optional
-        Data date/cycle to be used as title (default is None)
-    xlabel : str, optional
-        X label on plot (default is None)
-    ylabel : str, optional
-        Y label on plot (default is None)
+        x, y : (array type) The data required to create scatter plot
+        linear_regression : (bool, optional, default=True) To perform a linear regression and plot the line on the figure
+        density : (bool, optional, default=False) Plot a density scatter plot
+        color : (str, optional, default='darkgray') Color of scatter plot dots
+        cmap : (str, optional, default='magma') Color map of density scatter plot
+        r_color : (str, optional, default='black') Color of regression line when linear_regression=True
+        grid : (bool, optional, default=False) Plot grid on scatter plot
+        title : (str, optional, default='EmcPy Scatter Plot') Title to add to plot
+        time_title : (str, optional, default=None) Secondary title for date/cycle to add to plot
+        xlabel : (str, optional, default=None) X label on plot
+        ylabel : (str, optional, default=None) Y label on plot
 
     Returns
     -------
-    fig
-        Figure of the scatter plot
+        fig : (matplotlib figure object) Figure of the scatter plot
     """
 
     plotopts = {'linear_regression': linear_regression, 'density': density,

--- a/src/emcpy/stats.py
+++ b/src/emcpy/stats.py
@@ -21,7 +21,7 @@ def mstats(x):
 
     Parameters
     ----------
-        x : numpy variable whose statistics are to be computed and displayed
+        x : (numpy array) numpy variable whose statistics are to be computed and displayed
     '''
 
     OUT = type('', (), {})
@@ -88,15 +88,15 @@ def lregress(x, y, ci=95.0):
 
     Parameters
     ----------
-        x : independent variable
-        y : dependent variable
-        ci : confidence interval (default: 95%)
+        x : (array like) independent variable
+        y : (array like) dependent variable
+        ci : (float, optional, default=95) confidence interval percentage
 
     Returns
     -------
-        rc : linear regression coefficient
-        sb : standard error on the linear regression coefficient
-        ssig : statistical significance of the linear regression coefficient
+        rc : (float) linear regression coefficient
+        sb : (float) standard error on the linear regression coefficient
+        ssig : (bool) statistical significance of the linear regression coefficient
     '''
 
     # make sure the two samples are of the same size
@@ -132,15 +132,15 @@ def ttest(x, y=None, ci=95.0, paired=True, scale=False):
     Given two samples, perform the Student's t-test and return the errorbar.  The test assumes the sample size be the same between x and y.
     Parameters
     ----------
-        x: control
-        y: experiment (default: x)
-        ci: confidence interval (default: 95%)
-        paired: paired t-test (default: True)
-        scale: normalize with mean(x) and return as a percentage (default: False)
+        x: (numpy array) control
+        y: (numpy array, optional, default=x )experiment
+        ci: (float, optional, default=95) confidence interval percentage
+        paired: (bool, optional, default=True) paired t-test
+        scale: (bool, optional, default=False) normalize with mean(x) and return as a percentage
     Returns
     -------
-        diffmean: (normalized) difference in the sample means
-        errorbar: (normalized) errorbar with respect to control
+        diffmean: (numpy array) (normalized) difference in the sample means
+        errorbar: (numpy array) (normalized) errorbar with respect to control
 
     To mask out statistically significant values:\n
     `diffmask = numpy.ma.masked_where(numpy.abs(diffmean)<=errorbar,diffmean).mask`
@@ -183,10 +183,10 @@ def get_weights(lats):
     Get weights for latitudes to do weighted mean
     Parameters
     ----------
-        lats: Latitudes
+        lats: (array like) Latitudes
     Return
     ------
-        weights: weights for latitudes
+        weights: (numpy array) weights for latitudes
     '''
     return _np.cos((_np.pi / 180.0) * lats)
 
@@ -199,12 +199,12 @@ def get_weighted_mean(data, weights, axis=None):
     Uses `numpy.average`
     Parameters
     ----------
-        data: input data array
-        weights: input weights
-        axis: direction to compute weighted average
+        data: (numpy array) input data array
+        weights: (numpy array) input weights
+        axis: (int) direction to compute weighted average
     Returns
     -------
-        weighted average: data weighted mean by weights
+        weighted average: (numpy array) data weighted mean by weights
     '''
     assert data.shape == weights.shape, (
         'data and weights mis-match array size')
@@ -222,14 +222,14 @@ def get_linear_regression(x, y):
 
     Parameters
     ----------
-        y, x : array like, Data to calculate linear regression
+        y, x : (array like) Data to calculate linear regression
 
     Returns
     -------
-        y_pred : float, Predicted y values of from calculation
-        r_sq : float, R squared value
-        intercept : float, Intercept from slope intercept equation for y_pred
-        slope : float, Slope from slope intercept equation for y_pred
+        y_pred : (float) Predicted y values of from calculation
+        r_sq : (float) R squared value
+        intercept : (float) Intercept from slope intercept equation for y_pred
+        slope : (float) Slope from slope intercept equation for y_pred
     """
     x = x.reshape((-1, 1))
     model = LinearRegression().fit(x, y)

--- a/src/emcpy/stats.py
+++ b/src/emcpy/stats.py
@@ -19,8 +19,7 @@ def mstats(x):
 
     A better alternative is `scipy.stats.describe()`
 
-    Parameters
-    ----------
+    Args:
         x : (numpy array) numpy variable whose statistics are to be computed and displayed
     '''
 
@@ -86,17 +85,15 @@ def lregress(x, y, ci=95.0):
     returns the regression coefficient and statistical significance
     for a t-value at a desired confidence interval.
 
-    Parameters
-    ----------
+    Args:
         x : (array like) independent variable
         y : (array like) dependent variable
         ci : (float, optional, default=95) confidence interval percentage
 
-    Returns
-    -------
-        rc : (float) linear regression coefficient
-        sb : (float) standard error on the linear regression coefficient
-        ssig : (bool) statistical significance of the linear regression coefficient
+    Returns:
+        The linear regression coefficient (float),
+        the standard error on the linear regression coefficient (float),
+        and the statistical signficance of the linear regression coefficient (bool).
     '''
 
     # make sure the two samples are of the same size
@@ -130,17 +127,15 @@ def lregress(x, y, ci=95.0):
 def ttest(x, y=None, ci=95.0, paired=True, scale=False):
     '''
     Given two samples, perform the Student's t-test and return the errorbar.  The test assumes the sample size be the same between x and y.
-    Parameters
-    ----------
+    Args:
         x: (numpy array) control
         y: (numpy array, optional, default=x )experiment
         ci: (float, optional, default=95) confidence interval percentage
         paired: (bool, optional, default=True) paired t-test
         scale: (bool, optional, default=False) normalize with mean(x) and return as a percentage
-    Returns
-    -------
-        diffmean: (numpy array) (normalized) difference in the sample means
-        errorbar: (numpy array) (normalized) errorbar with respect to control
+    Returns:
+        The (normalized) difference in the sample means and
+        the (normalized) errorbar with respect to control.
 
     To mask out statistically significant values:\n
     `diffmask = numpy.ma.masked_where(numpy.abs(diffmean)<=errorbar,diffmean).mask`
@@ -181,12 +176,10 @@ def ttest(x, y=None, ci=95.0, paired=True, scale=False):
 def get_weights(lats):
     '''
     Get weights for latitudes to do weighted mean
-    Parameters
-    ----------
+    Args:
         lats: (array like) Latitudes
-    Return
-    ------
-        weights: (numpy array) weights for latitudes
+    Returns:
+        An array of weights for latitudes
     '''
     return _np.cos((_np.pi / 180.0) * lats)
 
@@ -197,14 +190,12 @@ def get_weighted_mean(data, weights, axis=None):
     of data in that direction
     Note, `data` and `weights` must be same dimension
     Uses `numpy.average`
-    Parameters
-    ----------
+    Args:
         data: (numpy array) input data array
         weights: (numpy array) input weights
         axis: (int) direction to compute weighted average
-    Returns
-    -------
-        weighted average: (numpy array) data weighted mean by weights
+    Returns:
+        An array of data weighted mean by weights
     '''
     assert data.shape == weights.shape, (
         'data and weights mis-match array size')
@@ -220,16 +211,13 @@ def get_linear_regression(x, y):
     in the dataset, and the targets predicted by the linear
     approximation.
 
-    Parameters
-    ----------
+    Args:
         y, x : (array like) Data to calculate linear regression
 
-    Returns
-    -------
-        y_pred : (float) Predicted y values of from calculation
-        r_sq : (float) R squared value
-        intercept : (float) Intercept from slope intercept equation for y_pred
-        slope : (float) Slope from slope intercept equation for y_pred
+    Returns:
+        The predicted y values from calculation,
+        the R squared value, the intercept of the line, and the slope of the line
+        from the equation for the predicted y values.
     """
     x = x.reshape((-1, 1))
     model = LinearRegression().fit(x, y)

--- a/src/emcpy/utils.py
+++ b/src/emcpy/utils.py
@@ -19,12 +19,10 @@ __all__ = [
 
 def float10Power(value):
     '''
-    Parameters
-    ----------
+    Args:
         value: value to get the 10^(exponent)
-    Return
-    ------
-        exponent: value expressed as 10^(exponent)
+    Returns:
+        The input value expressed as 10^(exponent).
     '''
     if value == 0:
         return 0
@@ -39,12 +37,10 @@ def float10Power(value):
 def roundNumber(value):
     '''
     Round the number to the nearest 10th.
-    Parameters
-    ----------
+    Args:
         value: Number to be rounded
-    Returns
-    -------
-        rounded_value: Number rounded to nearest 10th
+    Returns:
+        The input value rounded to nearest 10th
 
     Examples
     --------
@@ -65,8 +61,7 @@ def roundNumber(value):
 def pickle(filename, data, mode='wb'):
     '''
     Pickle `data` into a file
-    Parameters
-    ----------
+    Args:
         filename: (str) filename to pickle to
         data: (object) data to pickle
         mode: (str, optional, default='wb') mode to pickle
@@ -81,13 +76,11 @@ def pickle(filename, data, mode='wb'):
 
 def unpickle(filename, mode='rb'):
     '''
-    Parameters
-    ----------
+    Args:
         filename: (str) filename to unpickle to
         mode: (str, optional, default='rb') mode to unpickle
-    Return
-    ------
-        data: (object) unpickled data from filename
+    Returns:
+        The unpickled data from filename
     '''
     print(f'unpickling ... {filename}')
     try:
@@ -99,8 +92,7 @@ def unpickle(filename, mode='rb'):
 
 def writeHDF(filename, variable_name, data, complevel=0, complib=None, fletcher32=False):
     '''
-    Parameters
-    ----------
+    Args:
         filename: (str) HDF5 filename to write to
         variable_name: (str) name of the variable to write to
         data: (array like) variable data array
@@ -122,14 +114,12 @@ def writeHDF(filename, variable_name, data, complevel=0, complib=None, fletcher3
 
 def readHDF(filename, variable_name, **kwargs):
     '''
-    Parameters
-    ----------
+    Args:
         filename: (string) HDF5 filename to read from
         variable_name: (string) name of the variable to read from file
         **kwargs: additional arguments to pandas.read_hdf()
-    Return
-    ------
-        data: (Pandas DataFrame) data read from filename for variable_name
+    Returns:
+        A Pandas DataFrame of data read from filename for variable_name
     '''
     print(f'reading ... {filename}')
     try:
@@ -142,13 +132,11 @@ def readHDF(filename, variable_name, **kwargs):
 def EmptyDataFrame(columns, names, dtype=None):
     '''
     Create an empty Multi-index DataFrame
-    Parameters
-    ----------
+    Args:
         columns: (list of strings) name of all columns; including indices
         names: (list of strings) name of index columns
-    Return
-    ------
-        df = (Pandas DataFrame) Multi-index DataFrame object
+    Returns:
+        A Multi-index Pandas DataFrame object
     '''
 
     levels = [[] for i in range(len(names))]
@@ -162,8 +150,7 @@ def EmptyDataFrame(columns, names, dtype=None):
 def printcolour(text, colour='red'):
     '''
     Print the input text to stdout in color
-    Parameters
-    ----------
+    Args:
         text: (str) ascii text
         color: (str, optional, default='red') choice of color for text
     '''

--- a/src/emcpy/utils.py
+++ b/src/emcpy/utils.py
@@ -67,9 +67,9 @@ def pickle(filename, data, mode='wb'):
     Pickle `data` into a file
     Parameters
     ----------
-        filename: filename to pickle to
-        data: data to pickle
-        mode: mode to pickle (default: wb)
+        filename: (str) filename to pickle to
+        data: (object) data to pickle
+        mode: (str, optional, default='wb') mode to pickle
     '''
     print(f'pickling ... {filename}')
     try:
@@ -83,11 +83,11 @@ def unpickle(filename, mode='rb'):
     '''
     Parameters
     ----------
-        filename: filename to unpickle to
-        mode: mode to unpickle (default: rb)
+        filename: (str) filename to unpickle to
+        mode: (str, optional, default='rb') mode to unpickle
     Return
     ------
-        data: unpickled data from filename
+        data: (object) unpickled data from filename
     '''
     print(f'unpickling ... {filename}')
     try:
@@ -101,12 +101,12 @@ def writeHDF(filename, variable_name, data, complevel=0, complib=None, fletcher3
     '''
     Parameters
     ----------
-        filename: HDF5 filename to write to
-        variable_name: name of the variable to write to
-        data: variable data array
-        complevel: compression level (default: 0)
-        complib: compression library to choose from (default: None)
-        fletcher32: compression related option (default: False)
+        filename: (str) HDF5 filename to write to
+        variable_name: (str) name of the variable to write to
+        data: (array like) variable data array
+        complevel: (int, optional, default=0) compression level
+        complib: (str, optional, default=None) compression library to choose from
+        fletcher32: (bool, optional, default=False) compression related option
     '''
     print(f'writing ... {filename}')
     try:
@@ -124,12 +124,12 @@ def readHDF(filename, variable_name, **kwargs):
     '''
     Parameters
     ----------
-        filename: HDF5 filename to read from
-        variable_name: name of the variable to read from file
+        filename: (string) HDF5 filename to read from
+        variable_name: (string) name of the variable to read from file
         **kwargs: additional arguments to pandas.read_hdf()
     Return
     ------
-        data: data read from filename for variable_name
+        data: (Pandas DataFrame) data read from filename for variable_name
     '''
     print(f'reading ... {filename}')
     try:
@@ -144,11 +144,11 @@ def EmptyDataFrame(columns, names, dtype=None):
     Create an empty Multi-index DataFrame
     Parameters
     ----------
-        columns: name of all columns; including indices
-        names: name of index columns
+        columns: (list of strings) name of all columns; including indices
+        names: (list of strings) name of index columns
     Return
     ------
-        df = Multi-index DataFrame object
+        df = (Pandas DataFrame) Multi-index DataFrame object
     '''
 
     levels = [[] for i in range(len(names))]
@@ -164,8 +164,8 @@ def printcolour(text, colour='red'):
     Print the input text to stdout in color
     Parameters
     ----------
-        text: ascii text
-        color: choice of color for text (default: red)
+        text: (str) ascii text
+        color: (str, optional, default='red') choice of color for text
     '''
 
     colours = {


### PR DESCRIPTION
Another attempt to make the documentation look consistent.
- adds (float) or (array like) etc. to the parameters and returns for each function
- fixes indentation for scatter.py