### PR TITLE
added orientation option to add_colorbar()

### DIFF
--- a/src/emcpy/plots/create_map.py
+++ b/src/emcpy/plots/create_map.py
@@ -213,12 +213,14 @@ class CreateMap:
         self.ax.set_ylabel(ylabel=ylabel, loc=loc, fontsize=fontsize,
                            fontweight=fontweight, color=color)
 
-    def add_colorbar(self, label=None, label_fontsize=12, extend='neither'):
+    def add_colorbar(self, label=None, orientation='horizontal',
+                     label_fontsize=12, extend='neither'):
         """
         Creates new axes and adds colorbar to figure.
 
         Args:
             label : (str; default=None) Colorbar label
+            orientation  : (str; default='horizontal') colorbar orientation
             label_fontsize : (int; default=12) Colorbar label font size
             extend : (str; default='neither') Extends min/max side of colorbar
         """
@@ -226,12 +228,25 @@ class CreateMap:
         # object. If 'cs' exists, it will create a colorbar for the data
         # saved to the variable. 'cs' can be overwritten if plotting
         # multiple layers and with colorbar set to True.
-        if 'cs' in dir(self):
-            cax = self.fig.add_axes([self.ax.get_position().x1 + 0.02,
-                                     self.ax.get_position().y0, 0.025,
-                                     self.ax.get_position().height])
 
-            cb = plt.colorbar(self.cs, extend=extend, cax=cax)
+        from mpl_toolkits.axes_grid1.inset_locator import inset_axes
+
+        if 'cs' in dir(self):
+            if orientation == 'horizontal':
+                axins = inset_axes(self.ax,
+                                   width="95%",
+                                   height="5%",
+                                   loc='lower center',
+                                   borderpad=-8)
+            else:
+                axins = inset_axes(self.ax,
+                                   width="2.5%",
+                                   height="95%",
+                                   loc='right',
+                                   borderpad=-4)
+
+            cb = self.fig.colorbar(self.cs, extend=extend, cax=axins,
+                                   orientation=orientation)
             cb.set_label(label, fontsize=label_fontsize)
 
         else:

--- a/src/emcpy/plots/create_plot.py
+++ b/src/emcpy/plots/create_plot.py
@@ -315,12 +315,14 @@ class CreatePlot:
                              'len of yticks. Set yticks appropriately ' +
                              'or change labels to be len of yticks.')
 
-    def add_colorbar(self, label=None, label_fontsize=12, extend='neither'):
+    def add_colorbar(self, label=None, orientation='horizontal',
+                     label_fontsize=12, extend='neither'):
         """
         Creates new axes and adds colorbar to figure.
 
         Args:
             label : (str; default=None) Colorbar label
+            orientation  : (str; default='horizontal') colorbar orientation
             label_fontsize : (int; default=12) Colorbar label font size
             extend : (str; default='neither') Extends min/max side of colorbar
         """
@@ -328,17 +330,30 @@ class CreatePlot:
         # object. If 'cs' exists, it will create a colorbar for the data
         # saved to the variable. 'cs' can be overwritten if plotting
         # multiple layers and with colorbar set to True.
-        if 'cs' in dir(self):
-            cax = self.fig.add_axes([self.ax.get_position().x1 + 0.02,
-                                     self.ax.get_position().y0, 0.025,
-                                     self.ax.get_position().height])
 
-            cb = plt.colorbar(self.cs, extend=extend, cax=cax)
+        from mpl_toolkits.axes_grid1.inset_locator import inset_axes
+
+        if 'cs' in dir(self):
+            if orientation == 'horizontal':
+                axins = inset_axes(self.ax,
+                                   width="95%",
+                                   height="5%",
+                                   loc='lower center',
+                                   borderpad=-8)
+            else:
+                axins = inset_axes(self.ax,
+                                   width="2.5%",
+                                   height="95%",
+                                   loc='right',
+                                   borderpad=-4)
+
+            cb = self.fig.colorbar(self.cs, extend=extend, cax=axins,
+                                   orientation=orientation)
             cb.set_label(label, fontsize=label_fontsize)
 
         else:
-            raise TypeError('Data being plotted has no color series ' +
-                            'to plot. Make sure data requres a colorbar.')
+            raise TypeError('Data object has colorbar set to False.' +
+                            'Set obj.colorbar=True')
 
     def return_figure(self):
         """


### PR DESCRIPTION
This PR addresses issue #51. Now given an orientation option, colorbars can be displayed as vertical:

```
mymap.add_colorbar(label='colorbar label',
                   orientation='vertical',
                   label_fontsize=12, extend='both')
```
![image](https://user-images.githubusercontent.com/69815622/132373119-12016ac9-c7f9-4c64-b0b7-8131969031f5.png)

or horizontally:

```
mymap.add_colorbar(label='colorbar label',
                   orientation='horizontal',
                   label_fontsize=12, extend='both')
```
![image](https://user-images.githubusercontent.com/69815622/132373253-ed225ead-6387-4dd8-8140-a446f14bf106.png)

Default option is `horizontal`.
