### PR TITLE
Add method `add_text` to `create_plots.py`

### DIFF
--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -41,7 +41,8 @@ class EMCPyPlots:
             fontsize : (int; default=12) Text font size
             fontweight : (str; default='normal') Text font weight
             color : (str; default='k') Text font color
-            va : (str; default='baseline') Vertical alignment of text
+            verticalalignment : (str; default='baseline') Vertical
+                                alignment of text
         """
 
         self.ax.set_title(label, loc=loc, fontsize=fontsize,
@@ -144,6 +145,27 @@ class EMCPyPlots:
         self.ax.annotate(outstr, xy=(0.5, -0.1), xycoords='axes fraction',
                          fontsize=fontsize, horizontalalignment='center',
                          verticalalignment='top')
+
+    def add_text(self, xloc, yloc, text, fontsize=12,
+                 fontweight='normal', color='k', alpha=1.,
+                 horizontalalignment='center'):
+        """
+        Add text to a figure.
+
+        Args:
+            xloc : (int/float) x location on axis
+            yloc : (int/float) y location on axis
+            text : (str) Text to plot on figure
+            fontsize : (int; default=12) Text font size
+            fontweight : (str; default='normal') Text font weight
+            color : (str; default='k') Text font color
+            alpha : (float; default=1.) alpha of text
+            horizontalalignment : (str; default='baseline') Vertical
+                                alignment of text
+        """
+        self.ax.text(xloc, yloc, text, fontsize=fontsize,
+                     fontweight=fontweight, color=color,
+                     alpha=alpha, ha=horizontalalignment)
 
     def return_figure(self):
         """


### PR DESCRIPTION
A new method that allows a user to plot text on a figure axis. 

Example:
```
mymap = CreateMap(figsize=(12, 8),
                  domain=Domain('conus'),
                  proj_obj=MapProjection('plcarr'))
# Add coastlines
mymap.add_features(['coastlines'])
mymap.add_text(-97.5, 37.5, 'TEST', fontsize=32, alpha=0.8)
```
![image](https://user-images.githubusercontent.com/69815622/133849329-41661f7d-2248-4955-9993-3a364c3edddc.png)

```
data = np.array([])
histobj = Histogram(data)

myplot = CreatePlot()
myplot.draw_data([histobj])
myplot.add_text(0.5, 0, 'TEST')
```
![image](https://user-images.githubusercontent.com/69815622/133850347-34b84e44-9c1f-4b80-b9f1-d0d80506b279.png)
