### PR TITLE
Create 2D maps based just on location

### DIFF
--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -101,7 +101,7 @@ class EMCPyPlots:
         if yaxis == 'secondary':
             if self.shared_ax is None:
                 raise ValueError('Unable to add y label.  Secondary ' +
-                      'y axis does not exist.')
+                                 'y axis does not exist.')
             axis = self.shared_ax
 
         axis.set_ylabel(ylabel=ylabel, loc=loc, fontsize=fontsize,
@@ -168,13 +168,13 @@ class EMCPyPlots:
         self.ax.annotate(outstr, xy=(xloc, yloc), xycoords='axes fraction',
                          fontsize=fontsize, horizontalalignment='center',
                          verticalalignment='top')
-    
+
     def add_legend(self, loc='best',
                    fontsize='medium',
                    handlesize=20):
         """
         Adds legend to plot.
-        
+
         Args:
             loc : (str; default='best') location of the legend.
                  Options include: ['upper left', 'upper right',

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -168,6 +168,32 @@ class EMCPyPlots:
         self.ax.annotate(outstr, xy=(xloc, yloc), xycoords='axes fraction',
                          fontsize=fontsize, horizontalalignment='center',
                          verticalalignment='top')
+    
+    def add_legend(self, loc='best',
+                   fontsize='medium',
+                   handlesize=20):
+        """
+        Adds legend to plot.
+        
+        Args:
+            loc : (str; default='best') location of the legend.
+                 Options include: ['upper left', 'upper right',
+                 'lower left', 'lower right', 'upper center',
+                 'lower center', 'center left', 'center right',
+                 'center', 'best']
+            fontsize : (int or str; default='medium') the font
+                size of the legend.
+                Options include ['xx-small', 'x-small', 'small',
+                'medium', 'large', 'x-large', 'xx-large'] or an
+                integer value
+            handlesize : (int; default=20) changes the size of the
+                shape in the legend. ** Does not change size of a
+                line from a lineplot.
+        """
+
+        legend = self.ax.legend(loc=loc, fontsize=fontsize)
+        for i, key in enumerate(legend.legendHandles):
+            legend.legendHandles[i]._sizes = [handlesize]
 
     def add_text(self, xloc, yloc, text, fontsize=12,
                  fontweight='normal', color='k', alpha=1.,
@@ -379,14 +405,6 @@ class CreatePlot(EMCPyPlots):
             axis = self.ax
 
         return axis
-
-    def add_legend(self, loc='upper left',
-                   fontsize='medium'):
-        """
-        Adds legend to plot.
-        """
-
-        self.ax.legend(loc=loc, fontsize=fontsize)
 
     def add_grid(self,
                  linewidth=1,
@@ -617,16 +635,27 @@ class CreateMap(EMCPyPlots):
         """
         Plots MapScatter object on map axes.
         """
-
-        cs = self.ax.scatter(plot.longitude,
-                             plot.latitude,
-                             c=plot.data,
-                             s=plot.markersize,
-                             cmap=plot.cmap,
-                             marker=plot.marker,
-                             vmin=plot.vmin,
-                             vmax=plot.vmax,
-                             transform=self.proj_obj.projection)
+        if plot.data is None:
+            cs = self.ax.scatter(plot.longitude,
+                                 plot.latitude,
+                                 s=plot.markersize,
+                                 color=plot.color,
+                                 marker=plot.marker,
+                                 vmin=plot.vmin,
+                                 vmax=plot.vmax,
+                                 label=plot.label,
+                                 transform=self.proj_obj.projection)
+        else:
+            cs = self.ax.scatter(plot.longitude,
+                                 plot.latitude,
+                                 c=plot.data,
+                                 s=plot.markersize,
+                                 cmap=plot.cmap,
+                                 marker=plot.marker,
+                                 vmin=plot.vmin,
+                                 vmax=plot.vmax,
+                                 label=plot.label,
+                                 transform=self.proj_obj.projection)
         if plot.colorbar:
             self.cs = cs
 

--- a/src/emcpy/plots/map_plots.py
+++ b/src/emcpy/plots/map_plots.py
@@ -1,13 +1,13 @@
 class MapScatter:
 
-    def __init__(self, latitude, longitude, data):
+    def __init__(self, latitude, longitude, data=None):
         """
         Constructor for MapScatter.
 
         Args:
             latitude : (array type) Latitude data
             longitude : (array type) Longitude data
-            data : (array type) data to be plotted
+            data : (array type; default=None) data to be plotted
         """
         self.plottype = 'map_scatter'
 
@@ -17,12 +17,16 @@ class MapScatter:
 
         self.marker = 'o'
         self.markersize = 5
-        self.cmap = 'viridis'
+        if data is None:
+            self.color = 'tab:blue'
+        else:
+            self.cmap = 'viridis'
         self.edgecolors = None
         self.alpha = None
         self.vmin = None
         self.vmax = None
-        self.colorbar = True
+        self.label = None
+        self.colorbar = False if data is None else True
 
 
 class MapGridded:


### PR DESCRIPTION
2D maps can take in only lat and lon data and plot the location without needing a corresponding data point at that location. Useful for plotting location of specific QC flags for example:

![image](https://user-images.githubusercontent.com/69815622/137029358-7ad30a64-cdcb-4bdc-bc47-bfec162feeaa.png)
