### PR TITLE
Add feature to plot logos on plots

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ tests_require =
 where=src
 
 [options.package_data]
-* = *.txt, *.md, *.yaml *.png
+* = *.txt, *.md, *.yaml, *.png
 
 [green]
 file-pattern = test_*.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ tests_require =
 where=src
 
 [options.package_data]
-* = *.txt, *.md, *.yaml
+* = *.txt, *.md, *.yaml *.png
 
 [green]
 file-pattern = test_*.py

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 setuptools.setup(
-    package_data = {
+    package_data={
         '': ['src/emcpy/logos/*'],
-            }
+        }
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 import setuptools
 setuptools.setup(
-    package_data={
-        '': ['src/emcpy/logos/*'],
-        }
-)
+    package_data={'': ['src/emcpy/logos/*']}
+    )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,2 @@
 import setuptools
-setuptools.setup(
-    package_data={'': ['logos/*']}
-)
+setuptools.setup()

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 import setuptools
 setuptools.setup(
     package_data={'': ['src/emcpy/logos/*']}
-    )
+)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
 import setuptools
 setuptools.setup(
-    package_data={'': ['src/emcpy/logos/*']}
+    package_data={'': ['logos/*']}
 )

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,6 @@
 import setuptools
-setuptools.setup()
+setuptools.setup(
+    package_data = {
+        '': ['src/emcpy/logos/*'],
+            }
+)

--- a/src/emcpy/__init__.py
+++ b/src/emcpy/__init__.py
@@ -3,8 +3,11 @@
 """
 __docformat__ = "restructuredtext"
 
+import os
 import emcpy.calcs
 import emcpy.utils
 import emcpy.stats
 import emcpy.io.netCDF
 import emcpy.plots
+
+emcpy_directory = os.path.dirname(__file__)

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -1,10 +1,12 @@
 import numpy as np
+import emcpy
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import matplotlib.pyplot as plt
 from matplotlib import rcParams
 from matplotlib.figure import Figure
 from matplotlib.colors import Normalize
+import matplotlib.image as image
 from scipy.interpolate import interpn
 from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
 from emcpy.plots.map_tools import Domain, MapProjection
@@ -241,7 +243,33 @@ class EMCPyPlots:
         self.ax.text(xloc, yloc, text, fontsize=fontsize,
                      fontweight=fontweight, color=color,
                      alpha=alpha, ha=horizontalalignment)
+    
+    def add_logo(self, xloc, yloc, zorder=10, which='noaa/nws',
+                 alpha=0.5):
+        """
+        Add NOAA/NWS logo. Requires user to adjust x and y locations.
 
+        Args:
+            xloc : (int/float) x location on figure in pixels
+            yloc : (int/float) y location on figure in pixels
+            zorder : (int; default=10) The z order of the logo
+            which : (str; default='noaa/nws') which type of logo
+                    to plot. Options include 'noaa', 'nws', or
+                    'noaa/nws'
+            alpha : (float; default=0.5) alpha of the image 
+        """
+        image_dict = {
+            'noaa': 'noaa_logo_75x75.png',
+            'nws': 'nws_logo_75x75.png',
+            'noaa/nws': 'noaa_nws_logo_150x75.png'
+        }
+        
+        image_path = emcpy.emcpy_directory + '/logos/' + image_dict[which]
+        im = image.imread(image_path)
+
+        self.ax.figure.figimage(im, xo=xloc, yo=yloc, zorder=zorder,
+                                alpha=alpha)
+        
     def return_figure(self):
         """
         Returns the figure created.

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 import emcpy
 import cartopy.crs as ccrs
@@ -264,7 +265,7 @@ class EMCPyPlots:
             'noaa/nws': 'noaa_nws_logo_150x75.png'
         }
 
-        image_path = emcpy.emcpy_directory + '/logos/' + image_dict[which]
+        image_path = os.path.join(emcpy.emcpy_directory, 'logos', image_dict[which])
         im = image.imread(image_path)
 
         self.ax.figure.figimage(im, xo=xloc, yo=yloc, zorder=zorder,

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -243,7 +243,7 @@ class EMCPyPlots:
         self.ax.text(xloc, yloc, text, fontsize=fontsize,
                      fontweight=fontweight, color=color,
                      alpha=alpha, ha=horizontalalignment)
-    
+
     def add_logo(self, xloc, yloc, zorder=10, which='noaa/nws',
                  alpha=0.5):
         """
@@ -256,20 +256,20 @@ class EMCPyPlots:
             which : (str; default='noaa/nws') which type of logo
                     to plot. Options include 'noaa', 'nws', or
                     'noaa/nws'
-            alpha : (float; default=0.5) alpha of the image 
+            alpha : (float; default=0.5) alpha of the image
         """
         image_dict = {
             'noaa': 'noaa_logo_75x75.png',
             'nws': 'nws_logo_75x75.png',
             'noaa/nws': 'noaa_nws_logo_150x75.png'
         }
-        
+
         image_path = emcpy.emcpy_directory + '/logos/' + image_dict[which]
         im = image.imread(image_path)
 
         self.ax.figure.figimage(im, xo=xloc, yo=yloc, zorder=zorder,
                                 alpha=alpha)
-        
+
     def return_figure(self):
         """
         Returns the figure created.

--- a/src/tests/test_plots.py
+++ b/src/tests/test_plots.py
@@ -250,6 +250,33 @@ def test_horizontal_bar_plot():
     fig.savefig('test_horizontal_bar_plot.png')
 
 
+def test_add_logo():
+    # Test adding logos
+    x1, y1, x2, y2, x3, y3 = _getLineData()
+    lp1 = LinePlot(x1, y1)
+    lp1.label = 'line 1'
+
+    lp2 = LinePlot(x2, y2)
+    lp2.color = 'tab:green'
+    lp2.label = 'line 2'
+
+    lp3 = LinePlot(x3, y3)
+    lp3.color = 'tab:red'
+    lp3.label = 'line 3'
+
+    plt_list = [lp1, lp2, lp3]
+    myplt = CreatePlot()
+    myplt.draw_data(plt_list)
+
+    myplt.add_title(label='Test Line Plot')
+    myplt.add_xlabel(xlabel='X Axis Label')
+    myplt.add_ylabel(ylabel='Y Axis Label')
+    myplt.add_logo(400, 50, which='noaa')
+
+    fig = myplt.return_figure()
+    fig.savefig('test_add_logo.png')
+
+
 def _getLineData():
     # generate test data for line plots
 


### PR DESCRIPTION
Provide an option that allows users to plot a NOAA, NWS, or combination of both on their plot.

Examples:
```
sctr = Scatter(x, y)
myplt = CreatePlot()
plt_list = [sctr]
myplt.draw_data(plt_list)

myplt.add_logo(325, 30, which='noaa/nws')
```
![image](https://user-images.githubusercontent.com/69815622/145890187-667ca1b7-5d01-43cd-bb0d-67223da91d71.png)


```
sctr = Scatter(x, y)
myplt = CreatePlot()
plt_list = [sctr]
myplt.draw_data(plt_list)

myplt.add_logo(400, 30, which='noaa')
myplt.add_logo(45, 270, which='nws')
```
![image](https://user-images.githubusercontent.com/69815622/145890475-1ab33a15-2c20-4d33-b923-a9537c3de834.png)
