### PR TITLE
Add logos feature updated for declarative plotting changes

### DIFF
--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -1,13 +1,16 @@
 # This work developed by NOAA/NWS/EMC under the Apache 2.0 license.
 import os
+import emcpy
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
+from PIL import Image
 from scipy.interpolate import interpn
 from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
+from matplotlib.offsetbox import OffsetImage, AnchoredOffsetbox
 from emcpy.plots.map_tools import Domain, MapProjection
 from emcpy.stats import get_linear_regression
 
@@ -220,6 +223,12 @@ class CreateFigure:
         # Save figure
         self.fig.savefig(pathfile, **kwargs)
 
+    def tight_layout(self):
+        """
+        Set figure to tight layout.
+        """
+        self.fig.tight_layout()
+
     def close_figure(self):
         """
         Method to close figure
@@ -296,6 +305,48 @@ class CreateFigure:
         """
         if hasattr(self, 'fig'):
             self.fig.suptitle(text, **kwargs)
+
+    def plot_logo(self, loc, which='noaa/nws',
+                  zoom=1, alpha=0.5):
+        """
+        Add branding logo on all axes.
+        """
+        image_dict = {
+            'noaa': 'noaa_logo_75x75.png',
+            'nws': 'nws_logo_75x75.png',
+            'noaa/nws': 'noaa_nws_logo_150x75.png'
+        }
+
+        loc_dict = {
+            'upper right': 1,
+            'upper left': 2,
+            'bottom left': 3,
+            'bottom right': 4,
+            'right': 5,
+            'center left': 6,
+            'center right': 7,
+            'lower center': 8,
+            'upper center': 9,
+            'center': 10
+        }
+
+        image_path = os.path.join(emcpy.emcpy_directory, 'logos', image_dict[which])
+        im = Image.open(image_path)
+
+        ax_list = self.fig.axes
+
+        for ax in ax_list:
+            width, height = ax.figure.get_size_inches()*self.fig.dpi
+            wm_width = int(width/4)  # make the watermark 1/4 of the figure size
+            scaling = (wm_width / float(im.size[0]))
+            wm_height = int(float(im.size[1])*float(scaling))
+
+            imagebox = OffsetImage(im, zoom=zoom, alpha=alpha)
+            imagebox.image.axes = ax
+
+            ao = AnchoredOffsetbox(loc_dict[loc], pad=0.1, borderpad=0.1, child=imagebox)
+            ao.patch.set_alpha(0)
+            ax.add_artist(ao)
 
     def _plot_features(self, plot_obj, feature, ax):
 

--- a/src/tests/test_plots.py
+++ b/src/tests/test_plots.py
@@ -251,31 +251,29 @@ def test_horizontal_bar_plot():
     fig.create_figure()
     fig.save_figure('test_horizontal_bar_plot.png')
 
-# def test_add_logo():
-#     # Test adding logos
-#     x1, y1, x2, y2, x3, y3 = _getLineData()
-#     lp1 = LinePlot(x1, y1)
-#     lp1.label = 'line 1'
 
-#     lp2 = LinePlot(x2, y2)
-#     lp2.color = 'tab:green'
-#     lp2.label = 'line 2'
+def test_add_logo():
+    # Test adding logos
+    x1, y1, x2, y2, x3, y3 = _getLineData()
+    lp1 = LinePlot(x1, y1)
+    lp1.label = 'line 1'
 
-#     lp3 = LinePlot(x3, y3)
-#     lp3.color = 'tab:red'
-#     lp3.label = 'line 3'
+    plot1 = CreatePlot()
+    plot1.plot_layers = [lp1]
+    plot1.add_title('Test Line Plot')
+    plot1.add_xlabel('X Axis Label')
+    plot1.add_ylabel('Y Axis Label')
+    plot1.add_legend(loc='upper right')
 
-#     plt_list = [lp1, lp2, lp3]
-#     myplt = CreatePlot()
-#     myplt.draw_data(plt_list)
-
-#     myplt.add_title(label='Test Line Plot')
-#     myplt.add_xlabel(xlabel='X Axis Label')
-#     myplt.add_ylabel(ylabel='Y Axis Label')
-#     myplt.add_logo(400, 50, which='noaa')
-
-#     fig = myplt.return_figure()
-#     fig.savefig('test_add_logo.png')
+    fig = CreateFigure()
+    fig.plot_list = [plot1, plot1, plot1, plot1]
+    fig.nrows = 2
+    fig.ncols = 2
+    fig.figsize = (12, 8)
+    fig.create_figure()
+    fig.tight_layout()
+    fig.plot_logo(loc='bottom right', zoom=0.9, alpha=0.2)
+    fig.save_figure('test_add_logo.png')
 
 
 def test_multi_subplot():
@@ -345,6 +343,7 @@ def test_multi_subplot():
     fig.ncols = 2
     fig.nrows = 2
     fig.create_figure()
+    fig.tight_layout()
     fig.save_figure('test_multi_subplot.png')
 
 


### PR DESCRIPTION
Addresses issue #46. 

Adds option to plot either just NOAA logo, just NWS logo, or both. Plots logo on all axes.

![image](https://user-images.githubusercontent.com/69815622/191995872-2ee061bf-e79a-405a-affe-ae65c2cd9a52.png)
