### PR TITLE
add pip install to gh actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,10 @@ jobs:
     - name: Update conda
       run: conda update -n base -c defaults conda
 
+    # Intall pip
+    - name: Install pip
+      run: conda install pip
+    
     # Install cartopy
     - name: Install cartopy
       run: conda install -c conda-forge cartopy


### PR DESCRIPTION
Bugfix to fix github actions not installing pip.