### PR TITLE
Update requirements-github.txt to make CI pass

### DIFF
--- a/requirements-github.txt
+++ b/requirements-github.txt
@@ -2,7 +2,7 @@ pyyaml>=6.0
 pycodestyle==2.9.1
 netCDF4==1.6.1
 matplotlib==3.5.2
-cartopy==0.18.0
+cartopy==0.21.0
 scikit-learn==1.1.2
 xarray==2022.6.0
 pytest


### PR DESCRIPTION
Try using newer version of cartopy on GitHub to fix the issue since the ubuntu version didn't fix anything.