### PR TITLE
Make the plot annotation list based

### DIFF
--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -108,13 +108,16 @@ class CreatePlot:
     def add_text(self, xloc, yloc, text, transform='datacoords',
                  **kwargs):
 
-        self.text = {
+        if not hasattr(self, 'text'):
+            self.text = []
+
+        self.text.append({
             'xloc': xloc,
             'yloc': yloc,
             'text': text,
             'transform': transform,
             'kwargs': kwargs
-        }
+        })
 
     def add_grid(self, **kwargs):
 
@@ -659,20 +662,21 @@ class CreateFigure:
         for i, key in enumerate(leg.legendHandles):
             leg.legendHandles[i]._sizes = [20]
 
-    def _plot_text(self, ax, text):
+    def _plot_text(self, ax, text_in):
         """
         Add text on specified ax.
         """
-        if text['transform'] not in ['datacoords', 'axcoords']:
-            raise ValueError('Transform input is not valid. ' +
-                             'Valid options include ["datacoords", ' +
-                             '"axcoords"].')
+        for text in text_in:
+            if text['transform'] not in ['datacoords', 'axcoords']:
+                raise ValueError('Transform input is not valid. ' +
+                                 'Valid options include ["datacoords", ' +
+                                 '"axcoords"].')
 
-        transform = ax.transAxes if text['transform'] == 'axcoords' else ax.transData
+            transform = ax.transAxes if text['transform'] == 'axcoords' else ax.transData
 
-        ax.text(text['xloc'], text['yloc'],
-                text['text'], transform=transform,
-                **text['kwargs'])
+            ax.text(text['xloc'], text['yloc'],
+                    text['text'], transform=transform,
+                    **text['kwargs'])
 
     def _plot_grid(self, ax, grid):
         """


### PR DESCRIPTION
In order for a client of emcpy to annotate single plots with multiple strings (e.g. with different colors) the `add_text` `plot_text` parts of the code needs to be list based. This allows the clients to register multiple strings to be added to the plot.

Example plot from the eva client:

![gsi_omb_jedi_omb_histogram_aircraft_airTemperature](https://user-images.githubusercontent.com/27729500/223749507-954fe276-f178-49d2-8b44-a3a1b170ba9d.png)
