### PR TITLE
Add 3d gridded plotting capabilities

### DIFF
--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -441,7 +441,7 @@ class CreateFigure:
         inputs = self._get_inputs_dict(skipvars, plotobj)
 
         # Check for 3d data
-        if len(plotobj.longitude.shape) == 3:
+        if plotobj.longitude.ndim == 3:
             # Get total number of layers
             layers = plotobj.longitude.shape[0]
 

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -440,9 +440,22 @@ class CreateFigure:
                     'markersize', 'colorbar']
         inputs = self._get_inputs_dict(skipvars, plotobj)
 
-        cs = ax.pcolormesh(plotobj.latitude, plotobj.longitude,
-                           plotobj.data, **inputs,
-                           transform=self.projection.transform)
+        # Check for 3d data
+        if len(plotobj.longitude.shape) == 3:
+            # Get total number of layers
+            layers = plotobj.longitude.shape[0]
+
+            # Loop through layers and plot on one map
+            for i in range(layers):
+                cs = ax.pcolormesh(plotobj.longitude[i], plotobj.latitude[i],
+                                   plotobj.data[i], **inputs,
+                                   transform=self.projection.transform)
+
+        # Else, plot regular 2D data
+        else:
+            cs = ax.pcolormesh(plotobj.longitude, plotobj.latitude,
+                               plotobj.data, **inputs,
+                               transform=self.projection.transform)
 
         if plotobj.colorbar:
             self.cs = cs
@@ -453,7 +466,7 @@ class CreateFigure:
                     'markersize', 'colorbar']
         inputs = self._get_inputs_dict(skipvars, plotobj)
 
-        cs = ax.contour(plotobj.latitude, plotobj.longitude,
+        cs = ax.contour(plotobj.longitude, plotobj.latitude,
                         plotobj.data, **inputs,
                         transform=self.projection.transform)
 

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -442,13 +442,13 @@ class CreateFigure:
 
         # Check for 3d data
         if plotobj.longitude.ndim == 3:
-            # Get total number of layers
-            layers = plotobj.longitude.shape[0]
+            # Get total number of tiles; assumes Nth dimension is tile
+            tiles = plotobj.longitude.shape[-1]
 
-            # Loop through layers and plot on one map
-            for i in range(layers):
-                cs = ax.pcolormesh(plotobj.longitude[i], plotobj.latitude[i],
-                                   plotobj.data[i], **inputs,
+            # Loops through tiles to plot on one map
+            for i in range(tiles):
+                cs = ax.pcolormesh(plotobj.longitude[:,:,i], plotobj.latitude[:,:,i],
+                                   plotobj.data[:,:,i], **inputs,
                                    transform=self.projection.transform)
 
         # Else, plot regular 2D data

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -447,8 +447,9 @@ class CreateFigure:
 
             # Loops through tiles to plot on one map
             for i in range(tiles):
-                cs = ax.pcolormesh(plotobj.longitude[:,:,i], plotobj.latitude[:,:,i],
-                                   plotobj.data[:,:,i], **inputs,
+                cs = ax.pcolormesh(plotobj.longitude[:, :, i],
+                                   plotobj.latitude[:, :, i],
+                                   plotobj.data[:, :, i], **inputs,
                                    transform=self.projection.transform)
 
         # Else, plot regular 2D data

--- a/src/emcpy/plots/map_plots.py
+++ b/src/emcpy/plots/map_plots.py
@@ -54,7 +54,7 @@ class MapGridded:
         self.data = data
 
         self.cmap = 'viridis'
-        if len(latitude.shape) == 3:
+        if latitude.ndim == 3:
             self.vmin = np.nanmin(data)
             self.vmax = np.nanmax(data)
         else:

--- a/src/emcpy/plots/map_plots.py
+++ b/src/emcpy/plots/map_plots.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 __all__ = ['MapScatter', 'MapGridded', 'MapContour',
            'MapContourf']
 
@@ -52,8 +54,12 @@ class MapGridded:
         self.data = data
 
         self.cmap = 'viridis'
-        self.vmin = None
-        self.vmax = None
+        if len(latitude.shape) == 3:
+            self.vmin = np.nanmin(data)
+            self.vmax = np.nanmax(data)
+        else:
+            self.vmin = None
+            self.vmax = None
         self.alpha = None
         self.colorbar = True
 


### PR DESCRIPTION
There is a need to plot 3D gridded data for evaluation purposes. This PR allows for the input of 3D data that loops through each layer and plots.

The primary source of data we are imagining is coming from FV3 data, where there are 6 tiles that need to be plotted on one map. An example is this 2m temperate plot from fv3_core files:

![image](https://user-images.githubusercontent.com/69815622/226688506-e9a75514-c266-46a4-9842-f8050804953d.png)

Future cabilities such as contour/contourf plots can be added in the future, but want to to get a way to plot the FV3 tile data in EMCPy asap.