### PR TITLE
Add filled contour map plotting capabilities

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,11 +45,6 @@ extensions = [
 
 
 # Sphinx gallery configuration
-# gallery_order.py from the sphinxext folder provides the classes that
-# allow custom ordering of sections and subsections of the gallery
-from sphinxext.gallery_order import (
-    sectionorder as gallery_order_sectionorder,
-    subsectionorder as gallery_order_subsectionorder)
 
 # Create gallery dirs
 gallery_dirs = ["examples", "plot_types"]

--- a/galleries/examples/map_plots/filled_contour_map_plot.py
+++ b/galleries/examples/map_plots/filled_contour_map_plot.py
@@ -36,7 +36,7 @@ def main():
     z = z * -1.5 * y
 
     contourf = MapFilledContour(x, y, z)
-    contourf.cmap='viridis'
+    contourf.cmap = 'viridis'
     contour = MapContour(x, y, z)
 
     plot1 = CreatePlot()
@@ -56,4 +56,5 @@ def main():
 
 
 if __name__ == '__main__':
+
     main()

--- a/galleries/examples/map_plots/filled_contour_map_plot.py
+++ b/galleries/examples/map_plots/filled_contour_map_plot.py
@@ -1,0 +1,59 @@
+"""
+Plotting contours on a map plot
+-------------------------------
+
+The below example shows a map with plotted
+contour lines that are filled.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from emcpy.plots import CreatePlot, CreateFigure
+from emcpy.plots.map_tools import Domain, MapProjection
+from emcpy.plots.map_plots import MapContour, MapFilledContour
+
+
+def _getContourData(shape=(73, 145)):
+    # Generate test data for contour plots
+    nlats, nlons = shape
+    lats = np.linspace(-np.pi / 2, np.pi / 2, nlats)
+    lons = np.linspace(0, 2 * np.pi, nlons)
+    lons, lats = np.meshgrid(lons, lats)
+    wave = 0.75 * (np.sin(2 * lats) ** 8) * np.cos(4 * lons)
+    mean = 0.5 * np.cos(2 * lats) * ((np.sin(2 * lats)) ** 2 + 2)
+
+    lats = np.rad2deg(lats)
+    lons = np.rad2deg(lons)
+    data = wave + mean
+
+    return lons, lats, data
+
+
+def main():
+    # Get created test data
+    x, y, z = _getContourData((20, 40))
+    z = z * -1.5 * y
+
+    contourf = MapFilledContour(x, y, z)
+    contourf.cmap='viridis'
+    contour = MapContour(x, y, z)
+
+    plot1 = CreatePlot()
+    plot1.plot_layers = [contourf, contour]
+    plot1.projection = 'plcarr'
+    plot1.domain = 'global'
+    plot1.add_map_features(['coastline'])
+    plot1.add_xlabel(xlabel='longitude')
+    plot1.add_ylabel(ylabel='latitude')
+    plot1.add_title(label='Filled Contour Data', loc='center')
+
+    fig = CreateFigure()
+    fig.plot_list = [plot1]
+    fig.create_figure()
+
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -272,6 +272,7 @@ class CreateFigure:
             'map_scatter': self._map_scatter,
             'map_gridded': self._map_gridded,
             'map_contour': self._map_contour,
+            'map_filled_contour': self._map_filled_contour
         }
 
         gs = gridspec.GridSpec(self.nrows, self.ncols)
@@ -490,6 +491,22 @@ class CreateFigure:
         cs = ax.contour(plotobj.longitude, plotobj.latitude,
                         plotobj.data, **inputs,
                         transform=self.projection.transform)
+
+        if plotobj.clabel:
+            plt.clabel(cs, levels=plotobj.levels, use_clabeltext=True)
+
+        if plotobj.colorbar:
+            self.cs = cs
+
+    def _map_filled_contour(self, plotobj, ax):
+
+        skipvars = ['plottype', 'longitude', 'latitude', 'data',
+                    'colorbar']
+        inputs = self._get_inputs_dict(skipvars, plotobj)
+
+        cs = ax.contourf(plotobj.latitude, plotobj.longitude,
+                         plotobj.data, **inputs,
+                         transform=self.projection.projection)
 
         if plotobj.clabel:
             plt.clabel(cs, levels=plotobj.levels, use_clabeltext=True)

--- a/src/emcpy/plots/map_plots.py
+++ b/src/emcpy/plots/map_plots.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 __all__ = ['MapScatter', 'MapGridded', 'MapContour',
-           'MapContourf']
+           'MapFilledContour']
 
 
 class MapScatter:
@@ -87,6 +87,33 @@ class MapContour:
         self.linewidths = 1.5
         self.linestyles = '-'
         self.cmap = None
+        self.vmin = None
+        self.vmax = None
+        self.alpha = None
+        self.colorbar = False
+
+
+class MapFilledContour:
+
+    def __init__(self, latitude, longitude, data):
+        """
+        Constructor for MapFilledContour.
+
+        Args:
+            latitude : (array type) Latitude data
+            longitude : (array type) Longitude data
+            data : (array type) data to be plotted
+        """
+        self.plottype = 'map_filled_contour'
+
+        self.latitude = latitude
+        self.longitude = longitude
+        self.data = data
+
+        self.levels = None
+        self.clabel = False
+        self.colors = None
+        self.cmap = 'viridis'
         self.vmin = None
         self.vmax = None
         self.alpha = None

--- a/src/tests/test_map_plots.py
+++ b/src/tests/test_map_plots.py
@@ -225,7 +225,7 @@ def main():
     test_plot_map_scatter_2D_conus()
     test_plot_map_gridded_global()
     test_plot_map_contour_global()
-    test_plot_map_filled_contour_global
+    test_plot_map_filled_contour_global()
     test_plot_map_multidata_conus()
 
 

--- a/src/tests/test_map_plots.py
+++ b/src/tests/test_map_plots.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from emcpy.plots import CreatePlot, CreateFigure
 from emcpy.plots.map_tools import Domain, MapProjection
-from emcpy.plots.map_plots import MapScatter, MapGridded, MapContour
+from emcpy.plots.map_plots import MapScatter, MapGridded, MapContour, MapFilledContour
 
 
 def test_plot_global_map_no_features():
@@ -141,6 +141,29 @@ def test_plot_map_contour_global():
     fig.save_figure('test_plot_map_contour_global.png')
 
 
+def test_plot_map_filled_contour_global():
+    x, y, z = _getContourData((20, 40))
+    z = z * -1.5 * y
+
+    contourf = MapFilledContour(x, y, z)
+    contourf.cmap='viridis'
+    contour = MapContour(x, y, z)
+
+    plot1 = CreatePlot()
+    plot1.plot_layers = [contourf, contour]
+    plot1.projection = 'plcarr'
+    plot1.domain = 'global'
+    plot1.add_map_features(['coastline'])
+    plot1.add_xlabel(xlabel='longitude')
+    plot1.add_ylabel(ylabel='latitude')
+    plot1.add_title(label='Contourf Data', loc='center')
+
+    fig = CreateFigure()
+    fig.plot_list = [plot1]
+    fig.create_figure()
+    fig.save_figure('test_plot_map_contourf_global.png')
+
+
 def test_plot_map_multidata_conus():
     # Plot scatter and gridded data on CONUS domain
     lats = np.linspace(25, 50, 25)
@@ -193,3 +216,19 @@ def _getContourData(shape=(73, 145)):
     data = wave + mean
 
     return lons, lats, data
+
+def main():
+    
+    test_plot_global_map_no_features()
+    test_plot_global_map_coastlines()
+    test_plot_map_scatter_conus()
+    test_plot_map_scatter_2D_conus()
+    test_plot_map_gridded_global()
+    test_plot_map_contour_global()
+    test_plot_map_filled_contour_global
+    test_plot_map_multidata_conus()
+
+
+if __name__ == "__main__":
+
+    main()

--- a/src/tests/test_map_plots.py
+++ b/src/tests/test_map_plots.py
@@ -146,7 +146,7 @@ def test_plot_map_filled_contour_global():
     z = z * -1.5 * y
 
     contourf = MapFilledContour(x, y, z)
-    contourf.cmap='viridis'
+    contourf.cmap = 'viridis'
     contour = MapContour(x, y, z)
 
     plot1 = CreatePlot()
@@ -217,8 +217,9 @@ def _getContourData(shape=(73, 145)):
 
     return lons, lats, data
 
+
 def main():
-    
+
     test_plot_global_map_no_features()
     test_plot_global_map_coastlines()
     test_plot_map_scatter_conus()


### PR DESCRIPTION
There is a need to plot filled contour maps for eva [#216](https://github.com/JCSDA-internal/eva/pull/216).

The following adds those needed capabilities to EMCPy so they can be used in eva. 