### PR TITLE
Hotfix to fix error in map filled contour plotting

### DIFF
--- a/galleries/examples/map_plots/filled_contour_map_plot.py
+++ b/galleries/examples/map_plots/filled_contour_map_plot.py
@@ -27,13 +27,13 @@ def _getContourData(shape=(73, 145)):
     lons = np.rad2deg(lons)
     data = wave + mean
 
-    return lons, lats, data
+    return lats, lons, data
 
 
 def main():
     # Get created test data
     x, y, z = _getContourData((20, 40))
-    z = z * -1.5 * y
+    z = z * -1.5 * x
 
     contourf = MapFilledContour(x, y, z)
     contourf.cmap = 'viridis'

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -504,7 +504,7 @@ class CreateFigure:
                     'colorbar']
         inputs = self._get_inputs_dict(skipvars, plotobj)
 
-        cs = ax.contourf(plotobj.latitude, plotobj.longitude,
+        cs = ax.contourf(plotobj.longitude, plotobj.latitude,
                          plotobj.data, **inputs,
                          transform=self.projection.projection)
 

--- a/src/tests/test_map_plots.py
+++ b/src/tests/test_map_plots.py
@@ -121,7 +121,7 @@ def test_plot_map_gridded_global():
 
 def test_plot_map_contour_global():
     x, y, z = _getContourData((20, 40))
-    z = z * -1.5 * y
+    z = z * -1.5 * x
 
     contour = MapContour(x, y, z)
     gridded = MapGridded(x, y, z)
@@ -143,7 +143,7 @@ def test_plot_map_contour_global():
 
 def test_plot_map_filled_contour_global():
     x, y, z = _getContourData((20, 40))
-    z = z * -1.5 * y
+    z = z * -1.5 * x
 
     contourf = MapFilledContour(x, y, z)
     contourf.cmap = 'viridis'
@@ -215,7 +215,7 @@ def _getContourData(shape=(73, 145)):
     lons = np.rad2deg(lons)
     data = wave + mean
 
-    return lons, lats, data
+    return lats, lons, data
 
 
 def main():


### PR DESCRIPTION
There was a mistake in the initial PR that put latitudes and longitudes in the wrong order. This PR addresses those issues in the base code and examples.