### PR TITLE
Make subplot position detection Matplotlib-version-proof (GridSpec helpers) and fix single-colorbar/sharex/sharey logic

### DIFF
--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -867,15 +867,18 @@ class CreateFigure:
         if mappable is None:
             return
 
-        cb = None
         if colorbar['single_cbar']:
-            if ax.is_last_row() and ax.is_last_col():
+            # Only on the bottom-right subplot
+            if self._is_last_subplot(ax):
                 cbar_ax = self.fig.add_axes(colorbar['cbar_loc'])
                 cb = self.fig.colorbar(mappable, cax=cbar_ax, **colorbar['kwargs'])
-        else:
-            cb = self.fig.colorbar(mappable, ax=ax, **colorbar['kwargs'])
+                if colorbar['label'] is not None:
+                    cb.set_label(colorbar['label'], fontsize=colorbar['fontsize'])
+            return
 
-        if cb is not None and colorbar.get('label'):
+        # per-axes colorbar
+        cb = self.fig.colorbar(mappable, ax=ax, **colorbar['kwargs'])
+        if colorbar['label'] is not None:
             cb.set_label(colorbar['label'], fontsize=colorbar['fontsize'])
 
     def _plot_stats(self, ax, stats):
@@ -1125,15 +1128,44 @@ class CreateFigure:
         """
         If sharex axis is True, will find where to hide xticklabels.
         """
-        if not ax.is_last_row():
+        if not self._is_last_row(ax):
             plt.setp(ax.get_xticklabels(), visible=False)
 
     def _sharey(self, ax):
         """
         If sharey axis is True, will find where to hide yticklabels.
         """
-        if not ax.is_first_col():
+        if not self._is_first_col(ax):
             plt.setp(ax.get_yticklabels(), visible=False)
+
+    def _subplot_spec(self, ax):
+        """Return (ss, gs) or (None, None) if ax is not a GridSpec subplot."""
+        try:
+            ss = ax.get_subplotspec()
+            return ss, ss.get_gridspec()
+        except Exception:
+            return None, None
+
+    def _is_first_col(self, ax) -> bool:
+        ss, _ = self._subplot_spec(ax)
+        return bool(ss and ss.colspan.start == 0)
+
+    def _is_last_col(self, ax) -> bool:
+        ss, gs = self._subplot_spec(ax)
+        return bool(ss and gs and ss.colspan.stop == gs.ncols)
+
+    def _is_first_row(self, ax) -> bool:
+        ss, _ = self._subplot_spec(ax)
+        return bool(ss and ss.rowspan.start == 0)
+
+    def _is_last_row(self, ax) -> bool:
+        ss, gs = self._subplot_spec(ax)
+        return bool(ss and gs and ss.rowspan.stop == gs.nrows)
+
+    def _is_last_subplot(self, ax) -> bool:
+        """Bottom-right subplot in the current GridSpec."""
+        ss, gs = self._subplot_spec(ax)
+        return bool(ss and gs and ss.rowspan.stop == gs.nrows and ss.colspan.stop == gs.ncols)
 
     def _add_map_features(self, ax, map_features):
         """

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -1139,11 +1139,16 @@ class CreateFigure:
             plt.setp(ax.get_yticklabels(), visible=False)
 
     def _subplot_spec(self, ax):
-        """Return (ss, gs) or (None, None) if ax is not a GridSpec subplot."""
+        """
+        Return a tuple (ss, gs) where:
+            - ss is a matplotlib SubplotSpec object for the given axis.
+            - gs is the corresponding matplotlib GridSpec object.
+        Returns (None, None) if ax is not a GridSpec subplot.
+        """
         try:
             ss = ax.get_subplotspec()
             return ss, ss.get_gridspec()
-        except Exception:
+        except AttributeError:
             return None, None
 
     def _is_first_col(self, ax) -> bool:


### PR DESCRIPTION
## Summary
This PR replaces deprecated `Axes.is_last_row/is_first_col/is_last_col` usage with GridSpec-based helpers and updates colorbar/tick-sharing logic to call those helpers. This makes EMCPy plotting robust across newer Matplotlib versions and fixes the “single colorbar on last subplot only” behavior.

## Why
Recent Matplotlib versions no longer expose `Axes.is_last_row()` / `is_last_col()` on plain `Axes`. Our code relied on those helpers in:
  - _plot_colorbar (for `single_cbar=True`)
  - _sharex / _sharey (hiding tick labels on interior subplots)

This caused runtime `AttributeError` and failing tests on modern Matplotlib.

## Backward compatibility
- No public API changes. All changes are internal to CreateFigure.
- Compatible with both older and newer Matplotlib versions.
- Behavior is identical to previous intent (just implemented in a version-proof way).

## Risk / impact

Low. The helpers only read SubplotSpec/GridSpec metadata and bail out safely for non-subplot axes (e.g., colorbar axes).