### PR TITLE
Standardize Box-and-Whisker API (tick_labels only), harden kwargs, and stabilize scatter regression

### DIFF
--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -813,14 +813,14 @@ class CreateFigure:
         """
         skipvars = ['plottype', 'data']
         inputs = self._get_inputs_dict(skipvars, plotobj)
-    
+
         # Fail fast if the old kw is used.
         if 'labels' in inputs:
             raise TypeError(
                 "BoxandWhiskerPlot no longer supports 'labels'; use 'tick_labels' "
                 "(Matplotlib 3.9+)."
             )
-    
+
         ax.boxplot(plotobj.data, **inputs)
 
     def _get_inputs_dict(self, skipvars, plotobj):
@@ -830,8 +830,9 @@ class CreateFigure:
         """
         inputs = {}
         for v in [v for v in vars(plotobj) if v not in skipvars]:
-            inputs[v] = vars(plotobj)[v]
-
+            val = getattr(plotobj, v)
+            if val is not None:
+                inputs[v] = val
         return inputs
 
     def _plot_title(self, ax, title):

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -660,9 +660,9 @@ class CreateFigure:
                 label = f"y = {slope:.4f}x + {intercept:.4f}\nR\u00b2 : {r_sq:.4f}"
 
                 # User may provide a dict of style kwargs on the layer:
-                #   plotobj.linear_regression = {"linestyle": "--", "linewidth": 1.5, ...}
+                # plotobj.linear_regression = {"linestyle": "--", "linewidth": 1.5, ...}
                 # Treat it as optional.
-                style = getattr(plotobj, "linear_regression", None) or {}
+                style = getattr(plotobj, "linear_regression", {})
 
                 # Default the regression line color to the scatter's color
                 # unless the user already set one in `linear_regression`.

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -654,18 +654,24 @@ class CreateFigure:
                            **inputs)
 
         # checks to see if linear regression attribute
-        if plotobj.do_linear_regression:
-
-            # Assert that plotobj contains nonzero-length data
+        if getattr(plotobj, "do_linear_regression", False):
             if len(plotobj.x) != 0 and len(plotobj.y) != 0:
-                y_pred, r_sq, intercept, slope = get_linear_regression(plotobj.x,
-                                                                       plotobj.y)
+                y_pred, r_sq, intercept, slope = get_linear_regression(plotobj.x, plotobj.y)
                 label = f"y = {slope:.4f}x + {intercept:.4f}\nR\u00b2 : {r_sq:.4f}"
 
-                inputs = self._get_inputs_dict([], plotobj)
-                if 'color' in plotobj.linear_regression and 'color' in inputs:
-                    plotobj.linear_regression['color'] = inputs['color']
-                ax.plot(plotobj.x, y_pred, label=label, **plotobj.linear_regression)
+                # User may provide a dict of style kwargs on the layer:
+                #   plotobj.linear_regression = {"linestyle": "--", "linewidth": 1.5, ...}
+                # Treat it as optional.
+                style = getattr(plotobj, "linear_regression", None) or {}
+
+                # Default the regression line color to the scatter's color
+                # unless the user already set one in `linear_regression`.
+                if "color" not in style:
+                    point_color = getattr(plotobj, "color", None)
+                    if point_color is not None:
+                        style["color"] = point_color
+
+                ax.plot(plotobj.x, y_pred, label=label, **style)
 
     def _gridded(self, plotobj, ax):
         """
@@ -807,7 +813,14 @@ class CreateFigure:
         """
         skipvars = ['plottype', 'data']
         inputs = self._get_inputs_dict(skipvars, plotobj)
-
+    
+        # Fail fast if the old kw is used.
+        if 'labels' in inputs:
+            raise TypeError(
+                "BoxandWhiskerPlot no longer supports 'labels'; use 'tick_labels' "
+                "(Matplotlib 3.9+)."
+            )
+    
         ax.boxplot(plotobj.data, **inputs)
 
     def _get_inputs_dict(self, skipvars, plotobj):
@@ -900,8 +913,16 @@ class CreateFigure:
         """
         leg = ax.legend(**legend)
 
-        for handle in leg.legend_handles:
-            handle._sizes = [20]
+        # Matplotlib versions differ in attribute name
+        handles = getattr(leg, "legend_handles", None) or getattr(leg, "legendHandles", [])
+
+        for h in handles:
+            # PathCollection (scatter) has a public setter
+            if hasattr(h, "set_sizes"):
+                h.set_sizes([20])
+            # Fallback for older MPL where only the private attr exists
+            elif hasattr(h, "_sizes"):
+                h._sizes = [20]
 
     def _plot_text(self, ax, text_in):
         """

--- a/src/emcpy/plots/plots.py
+++ b/src/emcpy/plots/plots.py
@@ -393,8 +393,9 @@ class SkewT:
 
 
 class BoxandWhiskerPlot:
+
     def __init__(self, data):
-        super().__init__()
+
         self.plottype = 'boxandwhisker'
 
         self.data = data

--- a/src/emcpy/plots/plots.py
+++ b/src/emcpy/plots/plots.py
@@ -1,21 +1,23 @@
 # This work developed by NOAA/NWS/EMC under the Apache 2.0 license.
 import numpy as np
 
-__all__ = ['Scatter', 'Histogram', 'Density', 'LinePlot',
-           'VerticalLine', 'HorizontalLine', 'HorizontalSpan',
-           'BarPlot', 'HorizontalBar', 'SkewT']
+__all__ = [
+    'Scatter', 'Histogram', 'Density', 'LinePlot',
+    'VerticalLine', 'HorizontalLine', 'HorizontalSpan',
+    'BarPlot', 'HorizontalBar', 'SkewT',
+    'GriddedPlot', 'ContourPlot', 'FilledContourPlot',
+    'BoxandWhiskerPlot'
+]
 
 
 class Scatter:
-
     def __init__(self, x, y):
         """
-        Constructor for Scatter.
+        Scatter plot layer.
         Args:
-            x : (array type)
-            y : (array type)
+            x: array-like
+            y: array-like
         """
-
         super().__init__()
         self.plottype = 'scatter'
 
@@ -32,6 +34,9 @@ class Scatter:
         self.edgecolors = None
         self.label = f'n={np.count_nonzero(~np.isnan(x))}'
         self.do_linear_regression = False
+        # Optional style overrides for the regression line; kept empty by default.
+        # The renderer will default to the scatter color if 'color' isn't provided.
+        self.linear_regression = {}
 
     def add_linear_regression(self):
         """
@@ -388,14 +393,7 @@ class SkewT:
 
 
 class BoxandWhiskerPlot:
-
     def __init__(self, data):
-        """
-        Constructor to create a Box and Whisker
-        plot.
-        Args:
-            data : (array type)
-        """
         super().__init__()
         self.plottype = 'boxandwhisker'
 
@@ -411,7 +409,10 @@ class BoxandWhiskerPlot:
         self.positions = None
         self.widths = None
         self.patch_artist = False
-        self.labels = None
+
+        # Use the Matplotlib 3.9+ name only
+        self.tick_labels = None
+
         self.manage_ticks = True
         self.autorange = False
         self.meanline = False


### PR DESCRIPTION
## Summary

This PR aligns EMCPy with Matplotlib ≥ 3.9 by removing the legacy `labels` kwarg from `BoxandWhiskerPlot` in favor of `tick_labels`, filters out `None` kwargs before calling Matplotlib (avoids spurious deprecations), and initializes an empty `linear_regression` style dict on `Scatter` to prevent optional-attr errors.

## Why

- Matplotlib 3.9 renamed `boxplot(labels=...)` → `boxplot(tick_labels=...)`. Passing `labels` now raises a deprecation (treated as error in our tests).
- Forwarding `None` values into Matplotlib APIs can trip deprecations or type checks.
- `Scatter` regression rendering assumed `linear_regression` exists, causing an AttributeError when only `do_linear_regression=True` was set.

## What changed
### Plot layer API

- BoxandWhiskerPlot
  - Removed: `labels`
  - Added/kept: `tick_labels` (use this going forward)
- Scatter
  - Now sets self.linear_regression = {} by default (optional style overrides)

### Rendering / adapters
- `_get_inputs_dict(...)`: filters out `None` values so we don’t pass meaningless kwargs to Matplotlib.
- `_boxandwhisker(...)`: strictly supports `tick_labels` only; if `labels` is present, we raise a `TypeError` with a clear message to migrate to `tick_labels`.

### Breaking change
- `BoxandWhiskerPlot.labels` is removed. Consumers must set `tick_labels` instead.
- Rationale: this is a v2 branch; we prefer a clean, future-proof API over keeping legacy synonyms.
- Impact: minimal (box-and-whisker is sparsely used downstream).