### PR TITLE
Layer adapter/registry, per-layer validation, and optional-dep hardening

### DIFF
--- a/src/emcpy/plots/adapters.py
+++ b/src/emcpy/plots/adapters.py
@@ -27,39 +27,48 @@ def get_adapter(kind: str) -> LayerAdapter:
 
 # ---------------- Adapters (call existing renderers; add validation) ----------------
 
+
 @register
 class ScatterAdapter:
     plottype = "scatter"
+
     def render(self, fig, st: AxState, layer):
         x = np.asarray(layer.x); y = np.asarray(layer.y)
         if x.shape != y.shape:
             raise ValueError(f"Scatter: x and y must have same shape; got {x.shape} vs {y.shape}.")
         return fig._scatter(layer, st.ax)  # must return the PathCollection
 
+
 @register
 class LineAdapter:
     plottype = "line_plot"
+
     def render(self, fig, st: AxState, layer):
         x = np.asarray(layer.x); y = np.asarray(layer.y)
         if x.shape != y.shape:
             raise ValueError(f"LinePlot: x and y must have same shape; got {x.shape} vs {y.shape}.")
         return fig._lineplot(layer, st.ax)
 
+
 @register
 class HistogramAdapter:
     plottype = "histogram"
+
     def render(self, fig, st: AxState, layer):
         return fig._histogram(layer, st.ax)
+
 
 @register
 class DensityAdapter:
     plottype = "density"
+
     def render(self, fig, st: AxState, layer):
         try:
             import seaborn as _  # noqa
         except Exception as e:
             raise RuntimeError("Density layer requires 'seaborn' to be installed.") from e
         return fig._density(layer, st.ax)
+
 
 @register
 class GriddedAdapter:
@@ -107,27 +116,33 @@ class GriddedAdapter:
             "Use 1-D (monotonic) or 2-D meshgrid coordinates."
         )
 
+
 @register
 class ContourAdapter:
     plottype = "contour"
+
     def render(self, fig, st: AxState, layer):
         z = np.asarray(layer.z)
         if z.ndim != 2:
             raise ValueError(f"ContourPlot: z must be 2D; got {z.ndim}D.")
         return fig._contour(layer, st.ax)  # return ContourSet
 
+
 @register
 class FilledContourAdapter:
     plottype = "contourf"
+
     def render(self, fig, st: AxState, layer):
         z = np.asarray(layer.z)
         if z.ndim != 2:
             raise ValueError(f"FilledContourPlot: z must be 2D; got {z.ndim}D.")
         return fig._contourf(layer, st.ax)  # return ContourSet
 
+
 @register
 class VerticalLineAdapter:
     plottype = "vertical_line"
+
     def render(self, fig, st, layer):
         # numeric sanity
         try:
@@ -136,9 +151,11 @@ class VerticalLineAdapter:
             raise ValueError(f"VerticalLine: x must be numeric; got {layer.x!r}.") from e
         return fig._verticalline(layer, st.ax)  # likely returns Line2D (or None in current impl)
 
+
 @register
 class HorizontalLineAdapter:
     plottype = "horizontal_line"
+
     def render(self, fig, st, layer):
         try:
             float(layer.y)
@@ -146,9 +163,11 @@ class HorizontalLineAdapter:
             raise ValueError(f"HorizontalLine: y must be numeric; got {layer.y!r}.") from e
         return fig._horizontalline(layer, st.ax)
 
+
 @register
 class HorizontalSpanAdapter:
     plottype = "horizontal_span"
+    
     def render(self, fig, st, layer):
         # ensure bounds are finite; allow ymin > ymax (Matplotlib handles both)
         for name, val in (("ymin", layer.ymin), ("ymax", layer.ymax)):
@@ -158,9 +177,11 @@ class HorizontalSpanAdapter:
                 raise ValueError(f"HorizontalSpan: {name} must be numeric; got {val!r}.") from e
         return fig._horizontalspan(layer, st.ax)  # PolyCollection (or None)
 
+
 @register
 class BarAdapter:
     plottype = "bar_plot"
+
     def render(self, fig, st, layer):
         # Basic length check; Matplotlib is flexible with scalars, but we give clearer errors.
         x = np.asarray(layer.x)
@@ -169,9 +190,11 @@ class BarAdapter:
             raise ValueError(f"BarPlot: x and height must have same shape; got {x.shape} vs {h.shape}.")
         return fig._barplot(layer, st.ax)  # BarContainer
 
+
 @register
 class HorizontalBarAdapter:
     plottype = "horizontal_bar"
+
     def render(self, fig, st, layer):
         y = np.asarray(layer.y)
         w = np.asarray(layer.width)
@@ -179,9 +202,11 @@ class HorizontalBarAdapter:
             raise ValueError(f"HorizontalBar: y and width must have same shape; got {y.shape} vs {w.shape}.")
         return fig._hbar(layer, st.ax)  # BarContainer
 
+
 @register
 class SkewTAdapter:
     plottype = "skewt"
+
     def render(self, fig, st, layer):
         x = np.asarray(layer.x); y = np.asarray(layer.y)
         if x.shape != y.shape:
@@ -189,9 +214,11 @@ class SkewTAdapter:
         # Axis is already created with projection='skewx' in CreateFigure; just draw.
         return fig._skewt(layer, st.ax)  # returns list[Line2D] or None in current impl
 
+
 @register
 class BoxWhiskerAdapter:
     plottype = "boxandwhisker"
+
     def render(self, fig, st: AxState, layer):
         if getattr(layer, "tick_labels", None) is not None:
             n = len(layer.data) if hasattr(layer.data, "__len__") else None
@@ -200,27 +227,35 @@ class BoxWhiskerAdapter:
                                  f"must match number of boxes {n}.")
         return fig._boxandwhisker(layer, st.ax)
 
+
 # Map variants
 @register
 class MapScatterAdapter:
     plottype = "map_scatter"
+
     def render(self, fig, st: AxState, layer):
         return fig._map_scatter(layer, st.ax)
+
 
 @register
 class MapGriddedAdapter:
     plottype = "map_gridded"
+
     def render(self, fig, st: AxState, layer):
         return fig._map_gridded(layer, st.ax)
+
 
 @register
 class MapContourAdapter:
     plottype = "map_contour"
+
     def render(self, fig, st: AxState, layer):
         return fig._map_contour(layer, st.ax)
+
 
 @register
 class MapFilledContourAdapter:
     plottype = "map_filled_contour"
+
     def render(self, fig, st: AxState, layer):
         return fig._map_filled_contour(layer, st.ax)

--- a/src/emcpy/plots/adapters.py
+++ b/src/emcpy/plots/adapters.py
@@ -5,7 +5,7 @@ from typing import Any, ClassVar, Dict, Optional, Protocol, TYPE_CHECKING
 
 if TYPE_CHECKING:
     # Avoids runtime circular imports while keeping type safety
-    from .create_plots import CreateFigure, AxState
+    from .create_plots import CreateFigure
 
 
 class LayerAdapter(Protocol):

--- a/src/emcpy/plots/adapters.py
+++ b/src/emcpy/plots/adapters.py
@@ -5,7 +5,7 @@ from typing import Any, ClassVar, Dict, Optional, Protocol, TYPE_CHECKING
 
 if TYPE_CHECKING:
     # Avoids runtime circular imports while keeping type safety
-    from .create_plots import CreateFigure
+    from .create_plots import CreateFigure, AxState
 
 
 class LayerAdapter(Protocol):
@@ -84,7 +84,7 @@ class DensityAdapter:
     def render(self, fig, st: AxState, layer):
         try:
             import seaborn as _  # noqa
-        except Exception as e:
+        except ImportError as e:
             raise RuntimeError("Density layer requires 'seaborn' to be installed.") from e
         return fig._density(layer, st.ax)
 

--- a/src/emcpy/plots/adapters.py
+++ b/src/emcpy/plots/adapters.py
@@ -204,128 +204,20 @@ class BoxWhiskerAdapter:
 @register
 class MapScatterAdapter:
     plottype = "map_scatter"
-
     def render(self, fig, st: AxState, layer):
-        # Pull arrays
-        lon = np.asanyarray(layer.longitude)
-        lat = np.asanyarray(layer.latitude)
-        data = getattr(layer, "data", None)
-
-        # Collect kwargs like legacy renderer (leave out core data fields)
-        if data is None:
-            skip = ['plottype', 'longitude', 'latitude', 'markersize', 'integer_field', 'colorbar']
-        else:
-            skip = ['plottype', 'longitude', 'latitude', 'data', 'markersize', 'colorbar', 'normalize', 'integer_field']
-        inputs = fig._get_inputs_dict(skip, layer)
-
-        # Choose the CRS that represents the coordinate system of (lon, lat)
-        transform = getattr(getattr(fig, "projection", None), "transform", ccrs.PlateCarree())
-
-        # Plain 2D scatter (no color mapping)
-        if data is None:
-            pc = st.ax.scatter(lon, lat, s=layer.markersize, transform=transform, **inputs)
-            return pc  # PathCollection
-
-        # Colored scatter
-        integer_field = bool(getattr(layer, "integer_field", False))
-        norm = None
-        if integer_field:
-            # Require vmin/vmax to build integer bin boundaries
-            cmap_name = inputs.get('cmap', None) or matplotlib.rcParams.get('image.cmap', 'viridis')
-            cmap = matplotlib.cm.get_cmap(cmap_name)
-            vmin = inputs.get('vmin', None)
-            vmax = inputs.get('vmax', None)
-            if vmin is None or vmax is None:
-                raise ValueError("MapScatter with integer_field=True requires both vmin and vmax.")
-            norm = BoundaryNorm(np.arange(vmin - 0.5, vmax, 1), cmap.N)
-
-        pc = st.ax.scatter(lon, lat, c=data, s=layer.markersize, norm=norm, transform=transform, **inputs)
-
-        return pc  # PathCollection
+        return fig._map_scatter(layer, st.ax)
 
 @register
 class MapGriddedAdapter:
     plottype = "map_gridded"
-
     def render(self, fig, st: AxState, layer):
-        # Pull arrays in the map naming convention
-        X = np.asanyarray(layer.longitude)
-        Y = np.asanyarray(layer.latitude)
-        Z = np.asanyarray(layer.data)
-
-        # Mirror legacy kwargs behavior, but default shading='auto'
-        skip = ['plottype', 'longitude', 'latitude', 'data', 'markersize', 'colorbar']
-        inputs = fig._get_inputs_dict(skip, layer)
-        inputs.setdefault('shading', 'auto')
-
-        # Prefer the projection used when the Axes was created
-        transform = getattr(getattr(fig, "projection", None), "transform", ccrs.PlateCarree())
-
-        # --- 3D tiled case: (..., tiles) on the last axis
-        if X.ndim == 3 and Y.ndim == 3 and Z.ndim == 3:
-            if X.shape[:2] != Y.shape[:2] or X.shape != Z.shape:
-                raise ValueError(
-                    f"MapGridded (tiles): X,Y,Z shapes must match; got {X.shape}, {Y.shape}, {Z.shape}."
-                )
-            qm = None
-            tiles = X.shape[-1]
-            for i in range(tiles):
-                qm = st.ax.pcolormesh(X[:, :, i], Y[:, :, i], Z[:, :, i],
-                                      transform=transform, **inputs)
-            return qm  # QuadMesh from the last tile
-
-        # --- 2D meshgrid case
-        if X.ndim == 2 and Y.ndim == 2:
-            if X.shape != Y.shape:
-                raise ValueError(f"MapGridded: X and Y must share shape; got {X.shape} vs {Y.shape}.")
-            if Z.shape == X.shape or Z.shape == (X.shape[0] - 1, X.shape[1] - 1):
-                return st.ax.pcolormesh(X, Y, Z, transform=transform, **inputs)
-            raise ValueError(
-                "MapGridded (meshgrid): incompatible shapes: "
-                f"X/Y={X.shape}, Z={Z.shape}. "
-                "Expected Z to match X/Y or be one smaller in each dimension (edges)."
-            )
-
-        # --- 1D coordinate vectors (allowed; pcolormesh will grid them)
-        if X.ndim == 1 and Y.ndim == 1 and Z.ndim == 2:
-            nx, ny = len(X), len(Y)
-            zy, zx = Z.shape
-            if (zy, zx) in ((ny, nx), (ny - 1, nx - 1)):
-                return st.ax.pcolormesh(X, Y, Z, transform=transform, **inputs)
-            raise ValueError(
-                "MapGridded (1D coords): incompatible shapes: "
-                f"x(len)={nx}, y(len)={ny}, Z={Z.shape}. "
-                "Expected (ny, nx) for centers or (ny-1, nx-1) for edges."
-            )
-
-        raise ValueError(
-            f"MapGridded: unsupported coordinate dims "
-            f"(lon.ndim={X.ndim}, lat.ndim={Y.ndim}, data.ndim={Z.ndim})."
-        )
+        return fig._map_gridded(layer, st.ax)
 
 @register
 class MapContourAdapter:
     plottype = "map_contour"
-
     def render(self, fig, st: AxState, layer):
-        # Arrays: longitude (X), latitude (Y), data (Z)
-        X = np.asanyarray(layer.longitude)
-        Y = np.asanyarray(layer.latitude)
-        Z = np.asanyarray(layer.data)
-
-        skip = ['plottype', 'longitude', 'latitude', 'data', 'markersize', 'colorbar']
-        inputs = fig._get_inputs_dict(skip, layer)
-
-        transform = getattr(getattr(fig, "projection", None), "transform", ccrs.PlateCarree())
-
-        cs = st.ax.contour(X, Y, Z, transform=transform, **inputs)  # ContourSet
-
-        # Optional inline labels
-        if getattr(layer, 'clabel', False):
-            # Use provided levels if present; contour already computed levels otherwise
-            plt.clabel(cs, levels=getattr(layer, 'levels', None), use_clabeltext=True)
-
-        return cs  # ContourSet
+        return fig._map_contour(layer, st.ax)
 
 @register
 class MapFilledContourAdapter:

--- a/src/emcpy/plots/adapters.py
+++ b/src/emcpy/plots/adapters.py
@@ -64,17 +64,48 @@ class DensityAdapter:
 @register
 class GriddedAdapter:
     plottype = "gridded_plot"
+
     def render(self, fig, st: AxState, layer):
-        x = np.asarray(layer.x); y = np.asarray(layer.y); z = np.asarray(layer.z)
+        # Pull arrays
+        x = np.asanyarray(layer.x)
+        y = np.asanyarray(layer.y)
+        z = np.asanyarray(layer.z)
+
+        # Collect kwargs the same way the legacy renderer did
+        inputs = fig._get_inputs_dict(['plottype', 'plot_ax', 'x', 'y', 'z', 'colorbar'], layer)
+        # Ensure shading is 'auto' unless explicitly overridden
+        inputs.setdefault('shading', 'auto')
+
+        # 1-D coords: accept centers or edges
         if x.ndim == 1 and y.ndim == 1:
-            if z.shape != (len(y), len(x)):
-                raise ValueError(f"GriddedPlot: z.shape must be {(len(y), len(x))}; got {z.shape}.")
-        elif x.ndim == 2 and y.ndim == 2:
-            if not (x.shape == y.shape == z.shape):
-                raise ValueError(f"GriddedPlot: x,y,z must share shape; got x{tuple(x.shape)}, y{tuple(y.shape)}, z{tuple(z.shape)}.")
-        else:
-            raise ValueError("GriddedPlot: x,y must both be 1D or both be 2D meshgrid arrays.")
-        return fig._gridded(layer, st.ax)  # return QuadMesh
+            nx, ny = len(x), len(y)
+            zy, zx = z.shape
+            if (zy, zx) not in ((ny, nx), (ny - 1, nx - 1)):
+                raise ValueError(
+                    "GriddedPlot: incompatible shapes: "
+                    f"x(len)={nx}, y(len)={ny}, z.shape={z.shape}. "
+                    "Expected (ny, nx) for center coords or (ny-1, nx-1) for edge coords."
+                )
+            qm = st.ax.pcolormesh(x, y, z, **inputs)
+            return qm  # QuadMesh
+
+        # 2-D meshgrid coords: accept same-shape or edge-shape
+        if x.ndim == 2 and y.ndim == 2:
+            if x.shape != y.shape:
+                raise ValueError(f"GriddedPlot: X and Y must share shape; got {x.shape} vs {y.shape}.")
+            if z.shape == x.shape or z.shape == (x.shape[0] - 1, x.shape[1] - 1):
+                qm = st.ax.pcolormesh(x, y, z, **inputs)
+                return qm  # QuadMesh
+            raise ValueError(
+                "GriddedPlot (meshgrid): incompatible shapes: "
+                f"X/Y shape={x.shape}, Z shape={z.shape}. "
+                "Expected Z to match X/Y or be one smaller in each dimension (edges)."
+            )
+
+        raise ValueError(
+            f"GriddedPlot: unsupported coordinate dims: x.ndim={x.ndim}, y.ndim={y.ndim}. "
+            "Use 1-D (monotonic) or 2-D meshgrid coordinates."
+        )
 
 @register
 class ContourAdapter:
@@ -173,20 +204,128 @@ class BoxWhiskerAdapter:
 @register
 class MapScatterAdapter:
     plottype = "map_scatter"
+
     def render(self, fig, st: AxState, layer):
-        return fig._map_scatter(layer, st.ax)
+        # Pull arrays
+        lon = np.asanyarray(layer.longitude)
+        lat = np.asanyarray(layer.latitude)
+        data = getattr(layer, "data", None)
+
+        # Collect kwargs like legacy renderer (leave out core data fields)
+        if data is None:
+            skip = ['plottype', 'longitude', 'latitude', 'markersize', 'integer_field', 'colorbar']
+        else:
+            skip = ['plottype', 'longitude', 'latitude', 'data', 'markersize', 'colorbar', 'normalize', 'integer_field']
+        inputs = fig._get_inputs_dict(skip, layer)
+
+        # Choose the CRS that represents the coordinate system of (lon, lat)
+        transform = getattr(getattr(fig, "projection", None), "transform", ccrs.PlateCarree())
+
+        # Plain 2D scatter (no color mapping)
+        if data is None:
+            pc = st.ax.scatter(lon, lat, s=layer.markersize, transform=transform, **inputs)
+            return pc  # PathCollection
+
+        # Colored scatter
+        integer_field = bool(getattr(layer, "integer_field", False))
+        norm = None
+        if integer_field:
+            # Require vmin/vmax to build integer bin boundaries
+            cmap_name = inputs.get('cmap', None) or matplotlib.rcParams.get('image.cmap', 'viridis')
+            cmap = matplotlib.cm.get_cmap(cmap_name)
+            vmin = inputs.get('vmin', None)
+            vmax = inputs.get('vmax', None)
+            if vmin is None or vmax is None:
+                raise ValueError("MapScatter with integer_field=True requires both vmin and vmax.")
+            norm = BoundaryNorm(np.arange(vmin - 0.5, vmax, 1), cmap.N)
+
+        pc = st.ax.scatter(lon, lat, c=data, s=layer.markersize, norm=norm, transform=transform, **inputs)
+
+        return pc  # PathCollection
 
 @register
 class MapGriddedAdapter:
     plottype = "map_gridded"
+
     def render(self, fig, st: AxState, layer):
-        return fig._map_gridded(layer, st.ax)
+        # Pull arrays in the map naming convention
+        X = np.asanyarray(layer.longitude)
+        Y = np.asanyarray(layer.latitude)
+        Z = np.asanyarray(layer.data)
+
+        # Mirror legacy kwargs behavior, but default shading='auto'
+        skip = ['plottype', 'longitude', 'latitude', 'data', 'markersize', 'colorbar']
+        inputs = fig._get_inputs_dict(skip, layer)
+        inputs.setdefault('shading', 'auto')
+
+        # Prefer the projection used when the Axes was created
+        transform = getattr(getattr(fig, "projection", None), "transform", ccrs.PlateCarree())
+
+        # --- 3D tiled case: (..., tiles) on the last axis
+        if X.ndim == 3 and Y.ndim == 3 and Z.ndim == 3:
+            if X.shape[:2] != Y.shape[:2] or X.shape != Z.shape:
+                raise ValueError(
+                    f"MapGridded (tiles): X,Y,Z shapes must match; got {X.shape}, {Y.shape}, {Z.shape}."
+                )
+            qm = None
+            tiles = X.shape[-1]
+            for i in range(tiles):
+                qm = st.ax.pcolormesh(X[:, :, i], Y[:, :, i], Z[:, :, i],
+                                      transform=transform, **inputs)
+            return qm  # QuadMesh from the last tile
+
+        # --- 2D meshgrid case
+        if X.ndim == 2 and Y.ndim == 2:
+            if X.shape != Y.shape:
+                raise ValueError(f"MapGridded: X and Y must share shape; got {X.shape} vs {Y.shape}.")
+            if Z.shape == X.shape or Z.shape == (X.shape[0] - 1, X.shape[1] - 1):
+                return st.ax.pcolormesh(X, Y, Z, transform=transform, **inputs)
+            raise ValueError(
+                "MapGridded (meshgrid): incompatible shapes: "
+                f"X/Y={X.shape}, Z={Z.shape}. "
+                "Expected Z to match X/Y or be one smaller in each dimension (edges)."
+            )
+
+        # --- 1D coordinate vectors (allowed; pcolormesh will grid them)
+        if X.ndim == 1 and Y.ndim == 1 and Z.ndim == 2:
+            nx, ny = len(X), len(Y)
+            zy, zx = Z.shape
+            if (zy, zx) in ((ny, nx), (ny - 1, nx - 1)):
+                return st.ax.pcolormesh(X, Y, Z, transform=transform, **inputs)
+            raise ValueError(
+                "MapGridded (1D coords): incompatible shapes: "
+                f"x(len)={nx}, y(len)={ny}, Z={Z.shape}. "
+                "Expected (ny, nx) for centers or (ny-1, nx-1) for edges."
+            )
+
+        raise ValueError(
+            f"MapGridded: unsupported coordinate dims "
+            f"(lon.ndim={X.ndim}, lat.ndim={Y.ndim}, data.ndim={Z.ndim})."
+        )
 
 @register
 class MapContourAdapter:
     plottype = "map_contour"
+
     def render(self, fig, st: AxState, layer):
-        return fig._map_contour(layer, st.ax)
+        # Arrays: longitude (X), latitude (Y), data (Z)
+        X = np.asanyarray(layer.longitude)
+        Y = np.asanyarray(layer.latitude)
+        Z = np.asanyarray(layer.data)
+
+        skip = ['plottype', 'longitude', 'latitude', 'data', 'markersize', 'colorbar']
+        inputs = fig._get_inputs_dict(skip, layer)
+
+        transform = getattr(getattr(fig, "projection", None), "transform", ccrs.PlateCarree())
+
+        cs = st.ax.contour(X, Y, Z, transform=transform, **inputs)  # ContourSet
+
+        # Optional inline labels
+        if getattr(layer, 'clabel', False):
+            # Use provided levels if present; contour already computed levels otherwise
+            plt.clabel(cs, levels=getattr(layer, 'levels', None), use_clabeltext=True)
+
+        return cs  # ContourSet
 
 @register
 class MapFilledContourAdapter:

--- a/src/emcpy/plots/adapters.py
+++ b/src/emcpy/plots/adapters.py
@@ -1,34 +1,46 @@
 # emcpy/plots/adapters.py
 from __future__ import annotations
-from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Protocol
 import numpy as np
+from typing import Any, ClassVar, Dict, Optional, Protocol, TYPE_CHECKING
 
-
-@dataclass
-class AxState:
-    ax: Any
-    mappables: list[Any] = field(default_factory=list)
+if TYPE_CHECKING:
+    # Avoids runtime circular imports while keeping type safety
+    from .create_plots import CreateFigure, AxState
 
 
 class LayerAdapter(Protocol):
-    plottype: str
-    def render(self, fig, st: AxState, layer) -> Optional[Any]: ...
+    """Interface that all layer adapters implement."""
+    # Class-level key used to register this adapter
+    plottype: ClassVar[str]
+
+    def render(self, fig: "CreateFigure", st: "AxState", layer: Any) -> Optional[Any]:
+        """Render a single layer onto the given axes state and return the created artist, if any."""
+        ...
 
 
-_REGISTRY: Dict[str, LayerAdapter] = {}
+# Registry of plottype -> adapter class (not instances)
+_ADAPTERS: Dict[str, type[LayerAdapter]] = {}
 
 
-def register(cls):
-    _REGISTRY[cls.plottype] = cls()
+def register(cls: type[LayerAdapter]):
+    """Class decorator to register a LayerAdapter by its `plottype`."""
+    pt = getattr(cls, "plottype", None)
+    if not isinstance(pt, str) or not pt:
+        raise ValueError(f"{cls.__name__} must define a non-empty 'plottype' class attribute.")
+    if pt in _ADAPTERS:
+        raise ValueError(f"Adapter for plottype '{pt}' already registered: "
+                         f"{_ADAPTERS[pt].__name__}")
+    _ADAPTERS[pt] = cls
     return cls
 
 
 def get_adapter(kind: str) -> LayerAdapter:
+    """Return a fresh adapter instance for the given plottype."""
     try:
-        return _REGISTRY[kind]
+        adapter_cls = _ADAPTERS[kind]
     except KeyError as e:
-        raise KeyError(f"Unknown plottype '{kind}'. Registered: {list(_REGISTRY)}") from e
+        raise KeyError(f"Unknown plottype '{kind}'. Registered: {list(_ADAPTERS)}") from e
+    return adapter_cls()
 
 # ---------------- Adapters (call existing renderers; add validation) ----------------
 

--- a/src/emcpy/plots/adapters.py
+++ b/src/emcpy/plots/adapters.py
@@ -1,0 +1,195 @@
+# emcpy/plots/adapters.py
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Protocol
+import numpy as np
+
+@dataclass
+class AxState:
+    ax: Any
+    mappables: list[Any] = field(default_factory=list)
+
+class LayerAdapter(Protocol):
+    plottype: str
+    def render(self, fig, st: AxState, layer) -> Optional[Any]: ...
+
+_REGISTRY: Dict[str, LayerAdapter] = {}
+
+def register(cls):
+    _REGISTRY[cls.plottype] = cls()
+    return cls
+
+def get_adapter(kind: str) -> LayerAdapter:
+    try:
+        return _REGISTRY[kind]
+    except KeyError as e:
+        raise KeyError(f"Unknown plottype '{kind}'. Registered: {list(_REGISTRY)}") from e
+
+# ---------------- Adapters (call existing renderers; add validation) ----------------
+
+@register
+class ScatterAdapter:
+    plottype = "scatter"
+    def render(self, fig, st: AxState, layer):
+        x = np.asarray(layer.x); y = np.asarray(layer.y)
+        if x.shape != y.shape:
+            raise ValueError(f"Scatter: x and y must have same shape; got {x.shape} vs {y.shape}.")
+        return fig._scatter(layer, st.ax)  # must return the PathCollection
+
+@register
+class LineAdapter:
+    plottype = "line_plot"
+    def render(self, fig, st: AxState, layer):
+        x = np.asarray(layer.x); y = np.asarray(layer.y)
+        if x.shape != y.shape:
+            raise ValueError(f"LinePlot: x and y must have same shape; got {x.shape} vs {y.shape}.")
+        return fig._lineplot(layer, st.ax)
+
+@register
+class HistogramAdapter:
+    plottype = "histogram"
+    def render(self, fig, st: AxState, layer):
+        return fig._histogram(layer, st.ax)
+
+@register
+class DensityAdapter:
+    plottype = "density"
+    def render(self, fig, st: AxState, layer):
+        try:
+            import seaborn as _  # noqa
+        except Exception as e:
+            raise RuntimeError("Density layer requires 'seaborn' to be installed.") from e
+        return fig._density(layer, st.ax)
+
+@register
+class GriddedAdapter:
+    plottype = "gridded_plot"
+    def render(self, fig, st: AxState, layer):
+        x = np.asarray(layer.x); y = np.asarray(layer.y); z = np.asarray(layer.z)
+        if x.ndim == 1 and y.ndim == 1:
+            if z.shape != (len(y), len(x)):
+                raise ValueError(f"GriddedPlot: z.shape must be {(len(y), len(x))}; got {z.shape}.")
+        elif x.ndim == 2 and y.ndim == 2:
+            if not (x.shape == y.shape == z.shape):
+                raise ValueError(f"GriddedPlot: x,y,z must share shape; got x{tuple(x.shape)}, y{tuple(y.shape)}, z{tuple(z.shape)}.")
+        else:
+            raise ValueError("GriddedPlot: x,y must both be 1D or both be 2D meshgrid arrays.")
+        return fig._gridded(layer, st.ax)  # return QuadMesh
+
+@register
+class ContourAdapter:
+    plottype = "contour"
+    def render(self, fig, st: AxState, layer):
+        z = np.asarray(layer.z)
+        if z.ndim != 2:
+            raise ValueError(f"ContourPlot: z must be 2D; got {z.ndim}D.")
+        return fig._contour(layer, st.ax)  # return ContourSet
+
+@register
+class FilledContourAdapter:
+    plottype = "contourf"
+    def render(self, fig, st: AxState, layer):
+        z = np.asarray(layer.z)
+        if z.ndim != 2:
+            raise ValueError(f"FilledContourPlot: z must be 2D; got {z.ndim}D.")
+        return fig._contourf(layer, st.ax)  # return ContourSet
+
+@register
+class VerticalLineAdapter:
+    plottype = "vertical_line"
+    def render(self, fig, st, layer):
+        # numeric sanity
+        try:
+            float(layer.x)
+        except Exception as e:
+            raise ValueError(f"VerticalLine: x must be numeric; got {layer.x!r}.") from e
+        return fig._verticalline(layer, st.ax)  # likely returns Line2D (or None in current impl)
+
+@register
+class HorizontalLineAdapter:
+    plottype = "horizontal_line"
+    def render(self, fig, st, layer):
+        try:
+            float(layer.y)
+        except Exception as e:
+            raise ValueError(f"HorizontalLine: y must be numeric; got {layer.y!r}.") from e
+        return fig._horizontalline(layer, st.ax)
+
+@register
+class HorizontalSpanAdapter:
+    plottype = "horizontal_span"
+    def render(self, fig, st, layer):
+        # ensure bounds are finite; allow ymin > ymax (Matplotlib handles both)
+        for name, val in (("ymin", layer.ymin), ("ymax", layer.ymax)):
+            try:
+                float(val)
+            except Exception as e:
+                raise ValueError(f"HorizontalSpan: {name} must be numeric; got {val!r}.") from e
+        return fig._horizontalspan(layer, st.ax)  # PolyCollection (or None)
+
+@register
+class BarAdapter:
+    plottype = "bar_plot"
+    def render(self, fig, st, layer):
+        # Basic length check; Matplotlib is flexible with scalars, but we give clearer errors.
+        x = np.asarray(layer.x)
+        h = np.asarray(layer.height)
+        if x.shape != h.shape:
+            raise ValueError(f"BarPlot: x and height must have same shape; got {x.shape} vs {h.shape}.")
+        return fig._barplot(layer, st.ax)  # BarContainer
+
+@register
+class HorizontalBarAdapter:
+    plottype = "horizontal_bar"
+    def render(self, fig, st, layer):
+        y = np.asarray(layer.y)
+        w = np.asarray(layer.width)
+        if y.shape != w.shape:
+            raise ValueError(f"HorizontalBar: y and width must have same shape; got {y.shape} vs {w.shape}.")
+        return fig._hbar(layer, st.ax)  # BarContainer
+
+@register
+class SkewTAdapter:
+    plottype = "skewt"
+    def render(self, fig, st, layer):
+        x = np.asarray(layer.x); y = np.asarray(layer.y)
+        if x.shape != y.shape:
+            raise ValueError(f"SkewT: x and y must have same shape; got {x.shape} vs {y.shape}.")
+        # Axis is already created with projection='skewx' in CreateFigure; just draw.
+        return fig._skewt(layer, st.ax)  # returns list[Line2D] or None in current impl
+
+@register
+class BoxWhiskerAdapter:
+    plottype = "boxandwhisker"
+    def render(self, fig, st: AxState, layer):
+        if getattr(layer, "tick_labels", None) is not None:
+            n = len(layer.data) if hasattr(layer.data, "__len__") else None
+            if n is not None and len(layer.tick_labels) != n:
+                raise ValueError(f"BoxandWhiskerPlot: tick_labels length {len(layer.tick_labels)} "
+                                 f"must match number of boxes {n}.")
+        return fig._boxandwhisker(layer, st.ax)
+
+# Map variants
+@register
+class MapScatterAdapter:
+    plottype = "map_scatter"
+    def render(self, fig, st: AxState, layer):
+        return fig._map_scatter(layer, st.ax)
+
+@register
+class MapGriddedAdapter:
+    plottype = "map_gridded"
+    def render(self, fig, st: AxState, layer):
+        return fig._map_gridded(layer, st.ax)
+
+@register
+class MapContourAdapter:
+    plottype = "map_contour"
+    def render(self, fig, st: AxState, layer):
+        return fig._map_contour(layer, st.ax)
+
+@register
+class MapFilledContourAdapter:
+    plottype = "map_filled_contour"
+    def render(self, fig, st: AxState, layer):
+        return fig._map_filled_contour(layer, st.ax)

--- a/src/emcpy/plots/adapters.py
+++ b/src/emcpy/plots/adapters.py
@@ -4,20 +4,25 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Protocol
 import numpy as np
 
+
 @dataclass
 class AxState:
     ax: Any
     mappables: list[Any] = field(default_factory=list)
 
+
 class LayerAdapter(Protocol):
     plottype: str
     def render(self, fig, st: AxState, layer) -> Optional[Any]: ...
 
+
 _REGISTRY: Dict[str, LayerAdapter] = {}
+
 
 def register(cls):
     _REGISTRY[cls.plottype] = cls()
     return cls
+
 
 def get_adapter(kind: str) -> LayerAdapter:
     try:
@@ -33,7 +38,8 @@ class ScatterAdapter:
     plottype = "scatter"
 
     def render(self, fig, st: AxState, layer):
-        x = np.asarray(layer.x); y = np.asarray(layer.y)
+        x = np.asarray(layer.x)
+        y = np.asarray(layer.y)
         if x.shape != y.shape:
             raise ValueError(f"Scatter: x and y must have same shape; got {x.shape} vs {y.shape}.")
         return fig._scatter(layer, st.ax)  # must return the PathCollection
@@ -44,7 +50,8 @@ class LineAdapter:
     plottype = "line_plot"
 
     def render(self, fig, st: AxState, layer):
-        x = np.asarray(layer.x); y = np.asarray(layer.y)
+        x = np.asarray(layer.x)
+        y = np.asarray(layer.y)
         if x.shape != y.shape:
             raise ValueError(f"LinePlot: x and y must have same shape; got {x.shape} vs {y.shape}.")
         return fig._lineplot(layer, st.ax)
@@ -167,7 +174,7 @@ class HorizontalLineAdapter:
 @register
 class HorizontalSpanAdapter:
     plottype = "horizontal_span"
-    
+
     def render(self, fig, st, layer):
         # ensure bounds are finite; allow ymin > ymax (Matplotlib handles both)
         for name, val in (("ymin", layer.ymin), ("ymax", layer.ymax)):
@@ -208,7 +215,8 @@ class SkewTAdapter:
     plottype = "skewt"
 
     def render(self, fig, st, layer):
-        x = np.asarray(layer.x); y = np.asarray(layer.y)
+        x = np.asarray(layer.x)
+        y = np.asarray(layer.y)
         if x.shape != y.shape:
             raise ValueError(f"SkewT: x and y must have same shape; got {x.shape} vs {y.shape}.")
         # Axis is already created with projection='skewx' in CreateFigure; just draw.

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -468,7 +468,9 @@ class CreateFigure:
             vmin = inputs.get('vmin')
             vmax = inputs.get('vmax')
             if vmin is None or vmax is None:
-                raise ValueError("For integer_field=True, set both vmin and vmax.")
+                raise ValueError(
+                    "For integer_field=True, both vmin and vmax must " +
+                    "be provided on the MapScatter layer.")
             cmap_name = inputs.get('cmap', 'viridis')
             cmap = _cmaps.get_cmap(cmap_name)
             norm = matplotlib.colors.BoundaryNorm(
@@ -808,7 +810,7 @@ class CreateFigure:
                 return False
             try:
                 return np.size(arr) > 0
-            except Exception:
+            except (TypeError, AttributeError):
                 # If size introspection fails, err on the safe side and reject.
                 return False
 

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -477,6 +477,7 @@ class CreateFigure:
             inputs.setdefault('cmap', cmap)
 
         # If we’re passing c=..., drop conflicting color keys
+        inputs.pop('c', None)
         inputs.pop('color', None)
         inputs.pop('facecolor', None)
         inputs.pop('facecolors', None)
@@ -588,6 +589,8 @@ class CreateFigure:
         # If the layer provided a scalar/array color via `c`, remove conflicting color keys
         c_val = getattr(plotobj, 'c', None)
         if c_val is not None:
+            # kill all conflicting color sources
+            inputs.pop('c', None)
             inputs.pop('color', None)
             inputs.pop('facecolor', None)
             inputs.pop('facecolors', None)

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -22,7 +22,7 @@ from matplotlib.offsetbox import OffsetImage, AnchoredOffsetbox
 from matplotlib.ticker import MultipleLocator, FixedLocator, NullLocator
 from matplotlib.ticker import NullFormatter, ScalarFormatter
 from matplotlib.projections import register_projection
-from emcpy.plots.adapters import get_adapter, AxState
+from emcpy.plots.adapters import get_adapter
 from emcpy.plots.map_tools import Domain, MapProjection
 from emcpy.plots.skewt_projection import SkewXAxes
 from emcpy.stats.stats import get_linear_regression
@@ -34,6 +34,13 @@ try:
     register_projection(SkewXAxes)
 except ValueError:
     pass
+
+
+@dataclass
+class AxState:
+    ax: plt.Axes
+    mappables: List[Any] = field(default_factory=list)
+    is_map: bool = False
 
 
 class CreatePlot:

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -280,14 +280,14 @@ class CreateFigure:
                 'Number of plots does not match the number inputted rows'
                 'and columns.'
             )
-    
+
         gs = gridspec.GridSpec(self.nrows, self.ncols)
         self.fig = plt.figure(figsize=self.figsize)
-    
+
         # Track the last colorbar-capable artist per axes
         # (read by _last_mappable_for_ax in _plot_colorbar)
         self._ax_last_mappable = {}  # {Axes: mappable}
-    
+
         for i, plot_obj in enumerate(self.plot_list):
             # --- Axes creation (map vs. normal) ---
             if hasattr(plot_obj, 'projection'):
@@ -296,10 +296,10 @@ class CreateFigure:
                     self.domain = Domain(domain=plot_obj.domain[0], dd=plot_obj.domain[1])
                 else:
                     self.domain = Domain(plot_obj.domain)
-    
+
                 self.projection = MapProjection(plot_obj.projection)
                 ax = self.fig.add_subplot(gs[i], projection=self.projection.projection)
-    
+
                 if str(self.projection) not in ['npstere', 'spstere']:
                     ax.set_extent(self.domain.extent)
                     if str(self.projection) not in ['lamconf']:
@@ -311,7 +311,7 @@ class CreateFigure:
                         ax.yaxis.set_major_formatter(lat_formatter)
                 else:
                     ax.set_extent(self.domain.extent, ccrs.PlateCarree())
-    
+
             else:
                 # Regular Axes (SkewT gets its projection)
                 plot_types = [x.plottype for x in plot_obj.plot_layers]
@@ -319,10 +319,10 @@ class CreateFigure:
                     ax = self.fig.add_subplot(gs[i], projection='skewx')
                 else:
                     ax = self.fig.add_subplot(gs[i])
-    
+
             # --- Per-axes rendering state ---
             st = AxState(ax=ax)  # adapters append any mappables they create
-    
+
             # --- Render each layer via the adapter registry ---
             for layer in plot_obj.plot_layers:
                 adapter = get_adapter(layer.plottype)  # raises KeyError if unknown
@@ -330,11 +330,11 @@ class CreateFigure:
                 if mappable is not None:
                     st.mappables.append(mappable)
                     self._ax_last_mappable[ax] = mappable  # used by _plot_colorbar
-    
+
             # --- Plot figure/axes features (title, labels, ticks, colorbar, etc.) ---
             for feat in vars(plot_obj).keys():
                 self._plot_features(plot_obj, feat, ax)
-    
+
             # --- Shared axes label hiding ---
             if self.sharex:
                 self._sharex(ax)
@@ -454,7 +454,8 @@ class CreateFigure:
         norm = None
         if integer_field:
             cmap = matplotlib.cm.get_cmap(inputs['cmap'])
-            vmin = inputs['vmin']; vmax = inputs['vmax']
+            vmin = inputs['vmin']
+            vmax = inputs['vmax']
             if vmin is None or vmax is None:
                 raise ValueError("For integer_field=True, set both vmin and vmax.")
             norm = matplotlib.colors.BoundaryNorm(np.arange(vmin - 0.5, vmax, 1), cmap.N)
@@ -502,7 +503,7 @@ class CreateFigure:
             plt.clabel(cs, levels=plotobj.levels, use_clabeltext=True)
 
         return cs  # ContourSet
-    
+
     def _map_filled_contour(self, plotobj, ax):
 
         skip = ['plottype', 'longitude', 'latitude', 'data', 'colorbar']
@@ -529,7 +530,7 @@ class CreateFigure:
         )
         if plotobj.density['nsamples']:
             data = data / np.count_nonzero(_idx) * 100.0
-    
+
         z = interpn(
             (0.5 * (x_e[1:] + x_e[:-1]), 0.5 * (y_e[1:] + y_e[:-1])),
             data, np.vstack([plotobj.x, plotobj.y]).T,
@@ -541,7 +542,7 @@ class CreateFigure:
             x, y, z = plotobj.x[idx], plotobj.y[idx], z[idx]
         else:
             x, y = plotobj.x, plotobj.y
-    
+
         cs = ax.scatter(
             x, y, c=z, s=plotobj.markersize,
             cmap=plotobj.density['cmap'], label=plotobj.label
@@ -560,7 +561,7 @@ class CreateFigure:
                     'do_linear_regression', 'linear_regression', 'density', 'channel']
             inputs = self._get_inputs_dict(skip, plotobj)
             cs = ax.scatter(plotobj.x, plotobj.y, s=plotobj.markersize, **inputs)
-    
+
         # optional regression overlay (not a mappable)
         if getattr(plotobj, "do_linear_regression", False):
             if len(plotobj.x) and len(plotobj.y):
@@ -572,7 +573,7 @@ class CreateFigure:
                     if point_color is not None:
                         style["color"] = point_color
                 ax.plot(plotobj.x, y_pred, label=label, **style)
-    
+
         return cs  # PathCollection
 
     def _gridded(self, plotobj, ax):
@@ -714,10 +715,10 @@ class CreateFigure:
         """
         skip = ['plottype', 'data']
         inputs = self._get_inputs_dict(skip, plotobj)
-    
+
         if 'labels' in inputs:  # defensive against old kw
             raise TypeError("BoxandWhiskerPlot no longer supports 'labels'; use 'tick_labels' (Matplotlib 3.9+).")
-    
+
         bp = ax.boxplot(plotobj.data, **inputs)
 
         return bp  # dict of artists (not a ScalarMappable)
@@ -756,7 +757,7 @@ class CreateFigure:
     def _last_mappable_for_ax(self, ax: plt.Axes) -> Optional[Any]:
         """
         Return the most recently-added ScalarMappable for a given Axes.
-    
+
         Uses the adapter-tracked value first (set when a layer returns a
         mappable). Falls back to scanning Axes collections/images in reverse
         (newest-first). Intentionally ignores 'containers' (e.g., BarContainer),
@@ -765,7 +766,7 @@ class CreateFigure:
         m = getattr(self, "_ax_last_mappable", {}).get(ax)
         if isinstance(m, ScalarMappable):
             return m
-    
+
         # Fallback: newest-first among valid ScalarMappables
         for coll in reversed(ax.collections):
             if isinstance(coll, ScalarMappable):
@@ -773,7 +774,7 @@ class CreateFigure:
         for img in reversed(ax.images):
             if isinstance(img, ScalarMappable):
                 return img
-    
+
         return None
 
     def _plot_colorbar(self, ax, colorbar):

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -18,6 +18,7 @@ from PIL import Image
 from scipy.interpolate import interpn
 from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
 from matplotlib.cm import ScalarMappable
+from matplotlib.contour import ContourSet
 from matplotlib.offsetbox import OffsetImage, AnchoredOffsetbox
 from matplotlib.ticker import MultipleLocator, FixedLocator, NullLocator
 from matplotlib.ticker import NullFormatter, ScalarFormatter

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -17,6 +17,7 @@ from typing import Any, List, Optional
 from PIL import Image
 from scipy.interpolate import interpn
 from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
+from matplotlib import colormaps as _cmaps
 from matplotlib.cm import ScalarMappable
 from matplotlib.contour import ContourSet
 from matplotlib.offsetbox import OffsetImage, AnchoredOffsetbox
@@ -443,9 +444,10 @@ class CreateFigure:
 
     def _map_scatter(self, plotobj, ax):
 
-        integer_field = bool('integer_field' in vars(plotobj) and plotobj.integer_field)
+        integer_field = bool(getattr(plotobj, "integer_field", False))
 
         if plotobj.data is None:
+            # Plain point scatter (no scalar mapping)
             skip = ['plottype', 'longitude', 'latitude', 'markersize', 'integer_field', 'colorbar']
             inputs = self._get_inputs_dict(skip, plotobj)
             cs = ax.scatter(
@@ -453,28 +455,39 @@ class CreateFigure:
                 s=plotobj.markersize, **inputs,
                 transform=self.projection.transform
             )
-
-            return cs  # PathCollection
-
-        skip = ['plottype', 'longitude', 'latitude', 'data', 'markersize', 'colorbar', 'normalize', 'integer_field']
+            return cs  # PathCollection (no scalar array)
+    
+        # Scalar-mapped scatter
+        skip = ['plottype', 'longitude', 'latitude', 'data', 'markersize',
+                'colorbar', 'normalize', 'integer_field']
         inputs = self._get_inputs_dict(skip, plotobj)
-
+    
         norm = None
         if integer_field:
-            cmap = matplotlib.cm.get_cmap(inputs['cmap'])
-            vmin = inputs['vmin']
-            vmax = inputs['vmax']
+            # Validate before touching any colormap (prevents deprecation warning firing first)
+            vmin = inputs.get('vmin')
+            vmax = inputs.get('vmax')
             if vmin is None or vmax is None:
                 raise ValueError("For integer_field=True, set both vmin and vmax.")
-            norm = matplotlib.colors.BoundaryNorm(np.arange(vmin - 0.5, vmax, 1), cmap.N)
-
+    
+            # Modern colormap API (no deprecation)
+            cmap_name = inputs.get('cmap', 'viridis')
+            cmap = _cmaps.get_cmap(cmap_name)
+    
+            # Bin edges for integer classes, inclusive of top
+            norm = matplotlib.colors.BoundaryNorm(
+                np.arange(vmin - 0.5, vmax + 0.5, 1), cmap.N
+            )
+    
+            # Ensure the same cmap is used on the scatter call if not already provided
+            inputs.setdefault('cmap', cmap)
+    
         cs = ax.scatter(
             plotobj.longitude, plotobj.latitude,
             c=plotobj.data, s=plotobj.markersize,
             **inputs, norm=norm, transform=self.projection.transform
         )
-
-        return cs  # PathCollection
+        return cs  # PathCollection with scalar array
 
     def _map_gridded(self, plotobj, ax):
 

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -761,26 +761,40 @@ class CreateFigure:
         """
         ax.set_ylabel(**ylabel)
 
-    def _last_mappable_for_ax(self, ax: plt.Axes) -> Optional[Any]:
+    def _is_colorbar_source(self, m) -> bool:
         """
-        Return the most recently-added ScalarMappable for a given Axes.
+        Return True if artist 'm' can meaningfully drive a colorbar.
 
-        Uses the adapter-tracked value first (set when a layer returns a
-        mappable). Falls back to scanning Axes collections/images in reverse
-        (newest-first). Intentionally ignores 'containers' (e.g., BarContainer),
-        which are not ScalarMappable and cannot be used for colorbars.
+        Accept:
+          - ContourSet (levels/norm/cmap define the scale)
+          - ScalarMappable with a non-empty data array (e.g., PathCollection with 'c=',
+            QuadMesh from pcolormesh, Images, etc.)
+        Reject:
+          - Collections with only a constant facecolor (no scalar data attached)
+          - Anything that isn't a ScalarMappable/ContourSet
         """
-        m = getattr(self, "_ax_last_mappable", {}).get(ax)
+        if isinstance(m, ContourSet):
+            return True
         if isinstance(m, ScalarMappable):
-            return m
+            arr = m.get_array()
+            if arr is None:
+                return False
+            try:
+                return np.size(arr) > 0
+            except Exception:
+                # If size introspection fails, err on the safe side and reject.
+                return False
 
-        # Fallback: newest-first among valid ScalarMappables
-        for coll in reversed(ax.collections):
-            if isinstance(coll, ScalarMappable):
-                return coll
-        for img in reversed(ax.images):
-            if isinstance(img, ScalarMappable):
-                return img
+        return False
+
+    def _last_mappable_for_ax(self, ax) -> Optional[Any]:
+        """
+        Return the most recently-added *valid* colorbar source on this Axes.
+        """
+        # Newest-first search across typical mappable containers
+        for m in list(ax.collections[::-1]) + list(ax.images[::-1]) + list(ax.containers[::-1]):
+            if self._is_colorbar_source(m):
+                return m
 
         return None
 

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -799,21 +799,6 @@ class CreateFigure:
         if colorbar['label'] is not None:
             cb.set_label(colorbar['label'], fontsize=colorbar['fontsize'])
 
-    def _plot_colorbar(self, ax, colorbar):
-        mappable = self._last_mappable_for_ax(ax)
-        if mappable is None:
-            return
-        if colorbar['single_cbar']:
-            if self._is_last_subplot(ax):
-                cbar_ax = self.fig.add_axes(colorbar['cbar_loc'])
-                cb = self.fig.colorbar(mappable, cax=cbar_ax, **colorbar['kwargs'])
-                if colorbar['label'] is not None:
-                    cb.set_label(colorbar['label'], fontsize=colorbar['fontsize'])
-            return
-        cb = self.fig.colorbar(mappable, ax=ax, **colorbar['kwargs'])
-        if colorbar['label'] is not None:
-            cb.set_label(colorbar['label'], fontsize=colorbar['fontsize'])
-
     def _plot_stats(self, ax, stats):
         """
         Add annotated stats on specified ax.

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -17,10 +17,12 @@ from typing import Any, List, Optional
 from PIL import Image
 from scipy.interpolate import interpn
 from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
+from matplotlib.cm import ScalarMappable
 from matplotlib.offsetbox import OffsetImage, AnchoredOffsetbox
 from matplotlib.ticker import MultipleLocator, FixedLocator, NullLocator
 from matplotlib.ticker import NullFormatter, ScalarFormatter
 from matplotlib.projections import register_projection
+from emcpy.plots.adapters import get_adapter, AxState
 from emcpy.plots.map_tools import Domain, MapProjection
 from emcpy.plots.skewt_projection import SkewXAxes
 from emcpy.stats.stats import get_linear_regression
@@ -32,69 +34,6 @@ try:
     register_projection(SkewXAxes)
 except ValueError:
     pass
-
-
-@dataclass
-class AxState:
-    ax: plt.Axes
-    mappables: List[Any] = field(default_factory=list)
-    is_map: bool = False
-
-
-class LayerAdapter:
-    """
-    Thin wrapper around existing emcpy layer objects that forwards to the
-    current _plot_* methods and records any new 'mappable' created.
-    """
-    def __init__(self, plottype: str, plotobj: Any):
-        self.kind = plottype
-        self.plotobj = plotobj
-
-    def _snapshot(self, ax: plt.Axes) -> dict:
-        # Capture artists we consider "mappables"
-        return {
-            "collections": list(ax.collections),
-            "images": list(ax.images),
-            "containers": list(ax.containers),
-        }
-
-    def _diff_new_mappable(self, before: dict, after: dict) -> Optional[Any]:
-        # Prefer contour/pcolormesh/etc. (collections), then images, then containers
-        for key in ("collections", "images", "containers"):
-            b = before[key]
-            a = after[key]
-            if len(a) > len(b):
-                # Return the newest thing(s); choose the last added
-                return a[-1]
-        return None
-
-    def render(self, renderer: "CreateFigure", st: AxState) -> Optional[Any]:
-        # Reuse the existing plot dispatch (renderer has _scatter, _gridded, etc.)
-        plot_fn = {
-            'scatter': renderer._scatter,
-            'histogram': renderer._histogram,
-            'density': renderer._density,
-            'line_plot': renderer._lineplot,
-            'gridded_plot': renderer._gridded,
-            'contour': renderer._contour,
-            'contourf': renderer._contourf,
-            'vertical_line': renderer._verticalline,
-            'horizontal_line': renderer._horizontalline,
-            'horizontal_span': renderer._horizontalspan,
-            'bar_plot': renderer._barplot,
-            'horizontal_bar': renderer._hbar,
-            'skewt': renderer._skewt,
-            'boxandwhisker': renderer._boxandwhisker,
-            'map_scatter': renderer._map_scatter,
-            'map_gridded': renderer._map_gridded,
-            'map_contour': renderer._map_contour,
-            'map_filled_contour': renderer._map_filled_contour,
-        }[self.kind]
-
-        before = self._snapshot(st.ax)
-        plot_fn(self.plotobj, st.ax)
-        after = self._snapshot(st.ax)
-        return self._diff_new_mappable(before, after)
 
 
 class CreatePlot:
@@ -335,49 +274,32 @@ class CreateFigure:
         """
         Driver method to create figure and subplots.
         """
-        # Check to make sure plot_list == nrows*ncols
-        if len(self.plot_list) != self.nrows*self.ncols:
+        # Validate grid shape vs. plot_list
+        if len(self.plot_list) != self.nrows * self.ncols:
             raise ValueError(
                 'Number of plots does not match the number inputted rows'
-                'and columns.')
-
-        plot_dict = {
-            'scatter': self._scatter,
-            'histogram': self._histogram,
-            'density': self._density,
-            'line_plot': self._lineplot,
-            'gridded_plot': self._gridded,
-            'contour': self._contour,
-            'contourf': self._contourf,
-            'vertical_line': self._verticalline,
-            'horizontal_line': self._horizontalline,
-            'horizontal_span': self._horizontalspan,
-            'bar_plot': self._barplot,
-            'horizontal_bar': self._hbar,
-            'skewt': self._skewt,
-            'boxandwhisker': self._boxandwhisker,
-            'map_scatter': self._map_scatter,
-            'map_gridded': self._map_gridded,
-            'map_contour': self._map_contour,
-            'map_filled_contour': self._map_filled_contour
-        }
-
+                'and columns.'
+            )
+    
         gs = gridspec.GridSpec(self.nrows, self.ncols)
         self.fig = plt.figure(figsize=self.figsize)
-
+    
+        # Track the last colorbar-capable artist per axes
+        # (read by _last_mappable_for_ax in _plot_colorbar)
+        self._ax_last_mappable = {}  # {Axes: mappable}
+    
         for i, plot_obj in enumerate(self.plot_list):
-            # check if object has projection and domain attributes to determine ax
+            # --- Axes creation (map vs. normal) ---
             if hasattr(plot_obj, 'projection'):
-                # Check if domain object is tuple/list for custom domains
+                # Map: build domain/projection and a GeoAxes
                 if isinstance(plot_obj.domain, (tuple, list)):
                     self.domain = Domain(domain=plot_obj.domain[0], dd=plot_obj.domain[1])
                 else:
                     self.domain = Domain(plot_obj.domain)
-
+    
                 self.projection = MapProjection(plot_obj.projection)
-
-                # Set up axis specific things
                 ax = self.fig.add_subplot(gs[i], projection=self.projection.projection)
+    
                 if str(self.projection) not in ['npstere', 'spstere']:
                     ax.set_extent(self.domain.extent)
                     if str(self.projection) not in ['lamconf']:
@@ -389,30 +311,31 @@ class CreateFigure:
                         ax.yaxis.set_major_formatter(lat_formatter)
                 else:
                     ax.set_extent(self.domain.extent, ccrs.PlateCarree())
-
+    
             else:
-                # Check plot types
+                # Regular Axes (SkewT gets its projection)
                 plot_types = [x.plottype for x in plot_obj.plot_layers]
                 if 'skewt' in plot_types:
                     ax = self.fig.add_subplot(gs[i], projection='skewx')
                 else:
                     ax = self.fig.add_subplot(gs[i])
-
-            # Create per-axes state
-            ax_state = AxState(ax=ax, is_map=hasattr(plot_obj, 'projection'))
-
-            # With adapter-based rendering that records mappables
+    
+            # --- Per-axes rendering state ---
+            st = AxState(ax=ax)  # adapters append any mappables they create
+    
+            # --- Render each layer via the adapter registry ---
             for layer in plot_obj.plot_layers:
-                adapter = LayerAdapter(layer.plottype, layer)
-                m = adapter.render(self, ax_state)
-                if m is not None:
-                    ax_state.mappables.append(m)
-
-            # loop through all keys in an object and then call approriate
-            # method to plot the feature on the axis
+                adapter = get_adapter(layer.plottype)  # raises KeyError if unknown
+                mappable = adapter.render(self, st, layer)
+                if mappable is not None:
+                    st.mappables.append(mappable)
+                    self._ax_last_mappable[ax] = mappable  # used by _plot_colorbar
+    
+            # --- Plot figure/axes features (title, labels, ticks, colorbar, etc.) ---
             for feat in vars(plot_obj).keys():
                 self._plot_features(plot_obj, feat, ax)
-
+    
+            # --- Shared axes label hiding ---
             if self.sharex:
                 self._sharex(ax)
             if self.sharey:
@@ -512,99 +435,86 @@ class CreateFigure:
 
     def _map_scatter(self, plotobj, ax):
 
-        # Flag set for integer fields
-        integer_field = False
-        if 'integer_field' in vars(plotobj):
-            integer_field = True
+        integer_field = bool('integer_field' in vars(plotobj) and plotobj.integer_field)
 
         if plotobj.data is None:
-            skipvars = ['plottype', 'longitude', 'latitude',
-                        'markersize', 'integer_field', 'colorbar']
-            inputs = self._get_inputs_dict(skipvars, plotobj)
+            skip = ['plottype', 'longitude', 'latitude', 'markersize', 'integer_field', 'colorbar']
+            inputs = self._get_inputs_dict(skip, plotobj)
+            cs = ax.scatter(
+                plotobj.longitude, plotobj.latitude,
+                s=plotobj.markersize, **inputs,
+                transform=self.projection.transform
+            )
 
-            cs = ax.scatter(plotobj.longitude, plotobj.latitude,
-                            s=plotobj.markersize, **inputs,
-                            transform=self.projection.transform)
-        else:
-            skipvars = ['plottype', 'longitude', 'latitude',
-                        'data', 'markersize', 'colorbar', 'normalize', 'integer_field']
-            inputs = self._get_inputs_dict(skipvars, plotobj)
+            return cs  # PathCollection
 
-            norm = None
-            if integer_field:
-                cmap = matplotlib.cm.get_cmap(inputs['cmap'])
-                vmin = inputs['vmin']
-                vmax = inputs['vmax']
-                if vmin is None or vmax is None:
-                    print("Abort: vmin and vmax must be set for integer fields")
-                    exit()
-                norm = matplotlib.colors.BoundaryNorm(np.arange(vmin-0.5, vmax, 1), cmap.N)
+        skip = ['plottype', 'longitude', 'latitude', 'data', 'markersize', 'colorbar', 'normalize', 'integer_field']
+        inputs = self._get_inputs_dict(skip, plotobj)
 
-            cs = ax.scatter(plotobj.longitude, plotobj.latitude,
-                            c=plotobj.data, s=plotobj.markersize,
-                            **inputs, norm=norm, transform=self.projection.transform)
+        norm = None
+        if integer_field:
+            cmap = matplotlib.cm.get_cmap(inputs['cmap'])
+            vmin = inputs['vmin']; vmax = inputs['vmax']
+            if vmin is None or vmax is None:
+                raise ValueError("For integer_field=True, set both vmin and vmax.")
+            norm = matplotlib.colors.BoundaryNorm(np.arange(vmin - 0.5, vmax, 1), cmap.N)
 
-        if plotobj.colorbar:
-            self.cs = cs
+        cs = ax.scatter(
+            plotobj.longitude, plotobj.latitude,
+            c=plotobj.data, s=plotobj.markersize,
+            **inputs, norm=norm, transform=self.projection.transform
+        )
+
+        return cs  # PathCollection
 
     def _map_gridded(self, plotobj, ax):
 
-        skipvars = ['plottype', 'longitude', 'latitude', 'data',
-                    'markersize', 'colorbar']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
+        skip = ['plottype', 'longitude', 'latitude', 'data', 'markersize', 'colorbar']
+        inputs = self._get_inputs_dict(skip, plotobj)
 
-        # Check for 3d data
-        if plotobj.longitude.ndim == 3:
-            # Get total number of tiles; assumes Nth dimension is tile
+        cs = None
+        if getattr(plotobj.longitude, "ndim", 2) == 3:
             tiles = plotobj.longitude.shape[-1]
-
-            # Loops through tiles to plot on one map
             for i in range(tiles):
-                cs = ax.pcolormesh(plotobj.longitude[:, :, i],
-                                   plotobj.latitude[:, :, i],
-                                   plotobj.data[:, :, i], **inputs,
-                                   transform=self.projection.transform)
-
-        # Else, plot regular 2D data
+                cs = ax.pcolormesh(
+                    plotobj.longitude[:, :, i],
+                    plotobj.latitude[:, :, i],
+                    plotobj.data[:, :, i],
+                    **inputs, transform=self.projection.transform
+                )
         else:
-            cs = ax.pcolormesh(plotobj.longitude, plotobj.latitude,
-                               plotobj.data, **inputs,
-                               transform=self.projection.transform)
+            cs = ax.pcolormesh(
+                plotobj.longitude, plotobj.latitude, plotobj.data,
+                **inputs, transform=self.projection.transform
+            )
 
-        if plotobj.colorbar:
-            self.cs = cs
+        return cs  # QuadMesh (last plotted if multiple tiles)
 
     def _map_contour(self, plotobj, ax):
 
-        skipvars = ['plottype', 'longitude', 'latitude', 'data',
-                    'markersize', 'colorbar']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
-
-        cs = ax.contour(plotobj.longitude, plotobj.latitude,
-                        plotobj.data, **inputs,
-                        transform=self.projection.transform)
-
-        if plotobj.clabel:
+        skip = ['plottype', 'longitude', 'latitude', 'data', 'markersize', 'colorbar']
+        inputs = self._get_inputs_dict(skip, plotobj)
+        cs = ax.contour(
+            plotobj.longitude, plotobj.latitude, plotobj.data,
+            **inputs, transform=self.projection.transform
+        )
+        if getattr(plotobj, 'clabel', False):
             plt.clabel(cs, levels=plotobj.levels, use_clabeltext=True)
 
-        if plotobj.colorbar:
-            self.cs = cs
-
+        return cs  # ContourSet
+    
     def _map_filled_contour(self, plotobj, ax):
 
-        skipvars = ['plottype', 'longitude', 'latitude', 'data',
-                    'colorbar']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
-
-        cs = ax.contourf(plotobj.longitude, plotobj.latitude,
-                         plotobj.data, **inputs,
-                         transform=self.projection.projection)
-
-        if plotobj.clabel:
+        skip = ['plottype', 'longitude', 'latitude', 'data', 'colorbar']
+        inputs = self._get_inputs_dict(skip, plotobj)
+        cs = ax.contourf(
+            plotobj.longitude, plotobj.latitude, plotobj.data,
+            **inputs, transform=self.projection.projection
+        )
+        if getattr(plotobj, 'clabel', False):
             plt.clabel(cs, levels=plotobj.levels, use_clabeltext=True)
 
-        if plotobj.colorbar:
-            self.cs = cs
+        return cs  # ContourSet
 
     def _density_scatter(self, plotobj, ax):
         """
@@ -612,89 +522,128 @@ class CreateFigure:
         2d histogram.
         """
         _idx = np.logical_and(~np.isnan(plotobj.x), ~np.isnan(plotobj.y))
-        data, x_e, y_e = np.histogram2d(plotobj.x[_idx], plotobj.y[_idx],
-                                        bins=plotobj.density['bins'],
-                                        density=not plotobj.density['nsamples'])
+        data, x_e, y_e = np.histogram2d(
+            plotobj.x[_idx], plotobj.y[_idx],
+            bins=plotobj.density['bins'],
+            density=not plotobj.density['nsamples']
+        )
         if plotobj.density['nsamples']:
-            # compute percentage of total for each bin
-            data = data / np.count_nonzero(_idx) * 100.
-        z = interpn((0.5*(x_e[1:] + x_e[:-1]), 0.5*(y_e[1:]+y_e[:-1])),
-                    data, np.vstack([plotobj.x, plotobj.y]).T,
-                    method=plotobj.density['interp'], bounds_error=False)
-        # To be sure to plot all data
+            data = data / np.count_nonzero(_idx) * 100.0
+    
+        z = interpn(
+            (0.5 * (x_e[1:] + x_e[:-1]), 0.5 * (y_e[1:] + y_e[:-1])),
+            data, np.vstack([plotobj.x, plotobj.y]).T,
+            method=plotobj.density['interp'], bounds_error=False
+        )
         z[np.where(np.isnan(z))] = 0.0
-        # Sort the points by density, so that the densest
-        # points are plotted last
         if plotobj.density['sort']:
             idx = z.argsort()
             x, y, z = plotobj.x[idx], plotobj.y[idx], z[idx]
-        cs = ax.scatter(x, y, c=z,
-                        s=plotobj.markersize,
-                        cmap=plotobj.density['cmap'],
-                        label=plotobj.label)
-        # below doing nothing? fix/remove in subsequent PR?
-        # norm = Normalize(vmin=np.min(z), vmax=np.max(z))
+        else:
+            x, y = plotobj.x, plotobj.y
+    
+        cs = ax.scatter(
+            x, y, c=z, s=plotobj.markersize,
+            cmap=plotobj.density['cmap'], label=plotobj.label
+        )
 
-        if plotobj.density['colorbar']:
-            self.cs = cs
+        return cs  # PathCollection
 
     def _scatter(self, plotobj, ax):
         """
         Uses Scatter object to plot on axis.
         """
-        # checks to see if density attribute is True
         if hasattr(plotobj, 'density'):
-            self._density_scatter(plotobj, ax)
+            cs = self._density_scatter(plotobj, ax)
         else:
-            skipvars = ['plottype', 'plot_ax', 'x', 'y',
-                        'markersize', 'do_linear_regression',
-                        'linear_regression', 'density', 'channel']
-            inputs = self._get_inputs_dict(skipvars, plotobj)
-            s = ax.scatter(plotobj.x, plotobj.y, s=plotobj.markersize,
-                           **inputs)
-
-        # checks to see if linear regression attribute
+            skip = ['plottype', 'plot_ax', 'x', 'y', 'markersize',
+                    'do_linear_regression', 'linear_regression', 'density', 'channel']
+            inputs = self._get_inputs_dict(skip, plotobj)
+            cs = ax.scatter(plotobj.x, plotobj.y, s=plotobj.markersize, **inputs)
+    
+        # optional regression overlay (not a mappable)
         if getattr(plotobj, "do_linear_regression", False):
-            if len(plotobj.x) != 0 and len(plotobj.y) != 0:
+            if len(plotobj.x) and len(plotobj.y):
                 y_pred, r_sq, intercept, slope = get_linear_regression(plotobj.x, plotobj.y)
                 label = f"y = {slope:.4f}x + {intercept:.4f}\nR\u00b2 : {r_sq:.4f}"
-
-                # User may provide a dict of style kwargs on the layer:
-                # plotobj.linear_regression = {"linestyle": "--", "linewidth": 1.5, ...}
-                # Treat it as optional.
                 style = getattr(plotobj, "linear_regression", {})
-
-                # Default the regression line color to the scatter's color
-                # unless the user already set one in `linear_regression`.
                 if "color" not in style:
                     point_color = getattr(plotobj, "color", None)
                     if point_color is not None:
                         style["color"] = point_color
-
                 ax.plot(plotobj.x, y_pred, label=label, **style)
+    
+        return cs  # PathCollection
 
     def _gridded(self, plotobj, ax):
         """
         Uses Gridded object to plot on axis.
         """
-        skipvars = ['plottype', 'plot_ax', 'x', 'y', 'z',
-                    'colorbar']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
-
+        skip = ['plottype', 'plot_ax', 'x', 'y', 'z', 'colorbar']
+        inputs = self._get_inputs_dict(skip, plotobj)
         cs = ax.pcolormesh(plotobj.x, plotobj.y, plotobj.z, **inputs)
 
-        if plotobj.colorbar:
-            self.cs = cs
+        return cs  # QuadMesh
+
+    def _contour(self, plotobj, ax):
+        """
+        Uses ContourPlot object to plot on axis.
+        """
+        skip = ['plottype', 'x', 'y', 'z', 'colorbar']
+        inputs = self._get_inputs_dict(skip, plotobj)
+        cs = ax.contour(plotobj.x, plotobj.y, plotobj.z, **inputs)
+
+        return cs  # ContourSet
+
+    def _contourf(self, plotobj, ax):
+        """
+        Use FilledContourPlot object to plot on axis.
+        """
+        skip = ['plottype', 'x', 'y', 'z', 'colorbar']
+        inputs = self._get_inputs_dict(skip, plotobj)
+        cs = ax.contourf(plotobj.x, plotobj.y, plotobj.z, **inputs)
+
+        return cs  # ContourSet
+
+    def _histogram(self, plotobj, ax):
+        """
+        Uses Histogram object to plot on axis.
+        """
+        skip = ['plottype', 'plot_ax', 'data']
+        inputs = self._get_inputs_dict(skip, plotobj)
+        _, _, patches = ax.hist(plotobj.data, **inputs)
+
+        return patches  # list[Rectangle] (not a ScalarMappable)
+
+    def _density(self, plotobj, ax):
+        """
+        Uses Density object to plot on axis.
+        """
+        import seaborn as sns
+        skip = ['plottype', 'plot_ax', 'data']
+        inputs = self._get_inputs_dict(skip, plotobj)
+        artist = sns.kdeplot(data=plotobj.data, ax=ax, **inputs)
+
+        return artist  # Axes/Line2D-like (not a ScalarMappable)
+
+    def _lineplot(self, plotobj, ax):
+        """
+        Uses LinePlot object to plot on axis.
+        """
+        skip = ['plottype', 'plot_ax', 'x', 'y']
+        inputs = self._get_inputs_dict(skip, plotobj)
+        lines = ax.plot(plotobj.x, plotobj.y, **inputs)
+
+        return lines[0] if lines else None  # Line2D (not a ScalarMappable)
 
     def _skewt(self, plotobj, ax):
         """
         Creates a skewt-logp profile plot on axis.
         """
-        skipvars = ['plottype', 'plot_ax', 'x', 'y']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
-
+        skip = ['plottype', 'plot_ax', 'x', 'y']
+        inputs = self._get_inputs_dict(skip, plotobj)
         # Plot data using log scaling Y
-        ax.semilogy(plotobj.x, plotobj.y, **inputs)
+        lines = ax.semilogy(plotobj.x, plotobj.y, **inputs)
 
         # Disables the log-formatting that comes with semilogy
         ax.yaxis.set_major_formatter(ScalarFormatter())
@@ -707,121 +656,71 @@ class CreateFigure:
         ax.xaxis.set_major_locator(MultipleLocator(10))
         ax.set_xlim(-45, 30)
 
-    def _histogram(self, plotobj, ax):
-        """
-        Uses Histogram object to plot on axis.
-        """
-        skipvars = ['plottype', 'plot_ax', 'data']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
-
-        ax.hist(plotobj.data, **inputs)
-
-    def _density(self, plotobj, ax):
-        """
-        Uses Density object to plot on axis.
-        """
-        import seaborn as sns
-
-        skipvars = ['plottype', 'plot_ax', 'data']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
-
-        sns.kdeplot(data=plotobj.data, ax=ax, **inputs)
-
-    def _lineplot(self, plotobj, ax):
-        """
-        Uses LinePlot object to plot on axis.
-        """
-        skipvars = ['plottype', 'plot_ax', 'x', 'y']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
-
-        ax.plot(plotobj.x, plotobj.y, **inputs)
-
-    def _contour(self, plotobj, ax):
-        """
-        Uses ContourPlot object to plot on axis.
-        """
-        skipvars = ['plottype', 'x', 'y', 'z', 'colorbar']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
-
-        cs = ax.contour(plotobj.x, plotobj.y,
-                        plotobj.z, **inputs)
-
-        if plotobj.colorbar:
-            self.cs = cs
-
-    def _contourf(self, plotobj, ax):
-        """
-        Use FilledContourPlot object to plot on axis.
-        """
-        skipvars = ['plottype', 'x', 'y', 'z', 'colorbar']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
-
-        cs = ax.contourf(plotobj.x, plotobj.y,
-                         plotobj.z, **inputs)
-
-        if plotobj.colorbar:
-            self.cs = cs
+        return lines[0] if lines else None  # Line2D (not a ScalarMappable)
 
     def _verticalline(self, plotobj, ax):
         """
         Uses VerticalLine object to plot on axis.
         """
-        skipvars = ['plottype', 'plot_ax', 'x']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
+        skip = ['plottype', 'plot_ax', 'x']
+        inputs = self._get_inputs_dict(skip, plotobj)
+        ln = ax.axvline(plotobj.x, **inputs)
 
-        ax.axvline(plotobj.x, **inputs)
+        return ln  # Line2D
 
     def _horizontalline(self, plotobj, ax):
         """
         Uses HorizontalLine object to plot on axis.
         """
-        skipvars = ['plottype', 'plot_ax', 'y']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
+        skip = ['plottype', 'plot_ax', 'y']
+        inputs = self._get_inputs_dict(skip, plotobj)
+        ln = ax.axhline(plotobj.y, **inputs)
 
-        ax.axhline(plotobj.y, **inputs)
+        return ln  # Line2D
 
     def _horizontalspan(self, plotobj, ax):
         """
         Uses HorizontalSpan object to plot on axis.
         """
-        skipvars = ['plottype', 'plot_ax', 'ymin', 'ymax']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
+        skip = ['plottype', 'plot_ax', 'ymin', 'ymax']
+        inputs = self._get_inputs_dict(skip, plotobj)
+        poly = ax.axhspan(plotobj.ymin, plotobj.ymax, **inputs)
 
-        ax.axhspan(plotobj.ymin, plotobj.ymax, **inputs)
+        return poly  # PolyCollection
 
     def _barplot(self, plotobj, ax):
         """
         Uses BarPlot object to plot on axis.
         """
-        skipvars = ['plottype', 'plot_ax', 'x', 'height']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
+        skip = ['plottype', 'plot_ax', 'x', 'height']
+        inputs = self._get_inputs_dict(skip, plotobj)
+        cont = ax.bar(plotobj.x, plotobj.height, **inputs)
 
-        ax.bar(plotobj.x, plotobj.height, **inputs)
+        return cont  # BarContainer (not a ScalarMappable)
 
     def _hbar(self, plotobj, ax):
         """
         Uses HorizontalBar object to plot on axis.
         """
-        skipvars = ['plottype', 'plot_ax', 'y', 'width']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
+        skip = ['plottype', 'plot_ax', 'y', 'width']
+        inputs = self._get_inputs_dict(skip, plotobj)
+        cont = ax.barh(plotobj.y, plotobj.width, **inputs)
 
-        ax.barh(plotobj.y, plotobj.width, **inputs)
+        return cont  # BarContainer (not a ScalarMappable)
 
     def _boxandwhisker(self, plotobj, ax):
         """
         Uses BoxandWhiskerPlot object to plot on axis.
         """
-        skipvars = ['plottype', 'data']
-        inputs = self._get_inputs_dict(skipvars, plotobj)
+        skip = ['plottype', 'data']
+        inputs = self._get_inputs_dict(skip, plotobj)
+    
+        if 'labels' in inputs:  # defensive against old kw
+            raise TypeError("BoxandWhiskerPlot no longer supports 'labels'; use 'tick_labels' (Matplotlib 3.9+).")
+    
+        bp = ax.boxplot(plotobj.data, **inputs)
 
-        # Fail fast if the old kw is used.
-        if 'labels' in inputs:
-            raise TypeError(
-                "BoxandWhiskerPlot no longer supports 'labels'; use 'tick_labels' "
-                "(Matplotlib 3.9+)."
-            )
-
-        ax.boxplot(plotobj.data, **inputs)
+        return bp  # dict of artists (not a ScalarMappable)
 
     def _get_inputs_dict(self, skipvars, plotobj):
         """
@@ -833,6 +732,7 @@ class CreateFigure:
             val = getattr(plotobj, v)
             if val is not None:
                 inputs[v] = val
+
         return inputs
 
     def _plot_title(self, ax, title):
@@ -855,21 +755,25 @@ class CreateFigure:
 
     def _last_mappable_for_ax(self, ax: plt.Axes) -> Optional[Any]:
         """
-        Return the most recently-added "mappable" artist for a given Axes.
-
-        Mappables are objects Matplotlib colorbars can attach to
-        (e.g., ContourSet, QuadMesh, PathCollection, Image).
-        This helper inspects the Axes' collections, images, and
-        containers in reverse order and returns the newest one found.
-
-        Used by _plot_colorbar() to deterministically select the
-        correct source for the color scale, instead of relying on
-        global state like self.cs.
+        Return the most recently-added ScalarMappable for a given Axes.
+    
+        Uses the adapter-tracked value first (set when a layer returns a
+        mappable). Falls back to scanning Axes collections/images in reverse
+        (newest-first). Intentionally ignores 'containers' (e.g., BarContainer),
+        which are not ScalarMappable and cannot be used for colorbars.
         """
-        # Combine all mappables in reverse order of addition
-        mappables = list(ax.collections[::-1]) + list(ax.images[::-1]) + list(ax.containers[::-1])
-        for m in mappables:
+        m = getattr(self, "_ax_last_mappable", {}).get(ax)
+        if isinstance(m, ScalarMappable):
             return m
+    
+        # Fallback: newest-first among valid ScalarMappables
+        for coll in reversed(ax.collections):
+            if isinstance(coll, ScalarMappable):
+                return coll
+        for img in reversed(ax.images):
+            if isinstance(img, ScalarMappable):
+                return img
+    
         return None
 
     def _plot_colorbar(self, ax, colorbar):
@@ -891,6 +795,21 @@ class CreateFigure:
             return
 
         # per-axes colorbar
+        cb = self.fig.colorbar(mappable, ax=ax, **colorbar['kwargs'])
+        if colorbar['label'] is not None:
+            cb.set_label(colorbar['label'], fontsize=colorbar['fontsize'])
+
+    def _plot_colorbar(self, ax, colorbar):
+        mappable = self._last_mappable_for_ax(ax)
+        if mappable is None:
+            return
+        if colorbar['single_cbar']:
+            if self._is_last_subplot(ax):
+                cbar_ax = self.fig.add_axes(colorbar['cbar_loc'])
+                cb = self.fig.colorbar(mappable, cax=cbar_ax, **colorbar['kwargs'])
+                if colorbar['label'] is not None:
+                    cb.set_label(colorbar['label'], fontsize=colorbar['fontsize'])
+            return
         cb = self.fig.colorbar(mappable, ax=ax, **colorbar['kwargs'])
         if colorbar['label'] is not None:
             cb.set_label(colorbar['label'], fontsize=colorbar['fontsize'])

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -447,7 +447,7 @@ class CreateFigure:
         integer_field = bool(getattr(plotobj, "integer_field", False))
 
         if plotobj.data is None:
-            # Plain point scatter (no scalar mapping)
+            # unlabeled points (no scalar mapping)
             skip = ['plottype', 'longitude', 'latitude', 'markersize', 'integer_field', 'colorbar']
             inputs = self._get_inputs_dict(skip, plotobj)
             cs = ax.scatter(
@@ -455,39 +455,39 @@ class CreateFigure:
                 s=plotobj.markersize, **inputs,
                 transform=self.projection.transform
             )
-            return cs  # PathCollection (no scalar array)
-    
-        # Scalar-mapped scatter
+
+            return cs  # PathCollection (not scalar-mappable)
+
+        # scalar-mapped points
         skip = ['plottype', 'longitude', 'latitude', 'data', 'markersize',
                 'colorbar', 'normalize', 'integer_field']
         inputs = self._get_inputs_dict(skip, plotobj)
-    
+
         norm = None
         if integer_field:
-            # Validate before touching any colormap (prevents deprecation warning firing first)
             vmin = inputs.get('vmin')
             vmax = inputs.get('vmax')
             if vmin is None or vmax is None:
                 raise ValueError("For integer_field=True, set both vmin and vmax.")
-    
-            # Modern colormap API (no deprecation)
             cmap_name = inputs.get('cmap', 'viridis')
             cmap = _cmaps.get_cmap(cmap_name)
-    
-            # Bin edges for integer classes, inclusive of top
             norm = matplotlib.colors.BoundaryNorm(
                 np.arange(vmin - 0.5, vmax + 0.5, 1), cmap.N
             )
-    
-            # Ensure the same cmap is used on the scatter call if not already provided
             inputs.setdefault('cmap', cmap)
-    
+
+        # If we’re passing c=..., drop conflicting color keys
+        inputs.pop('color', None)
+        inputs.pop('facecolor', None)
+        inputs.pop('facecolors', None)
+
         cs = ax.scatter(
             plotobj.longitude, plotobj.latitude,
             c=plotobj.data, s=plotobj.markersize,
             **inputs, norm=norm, transform=self.projection.transform
         )
-        return cs  # PathCollection with scalar array
+
+        return cs
 
     def _map_gridded(self, plotobj, ax):
 
@@ -574,28 +574,38 @@ class CreateFigure:
     def _scatter(self, plotobj, ax):
         """
         Uses Scatter object to plot on axis.
+        Returns the PathCollection (mappable when `c` is provided).
         """
+        # density mode uses a different path
         if hasattr(plotobj, 'density'):
-            cs = self._density_scatter(plotobj, ax)
+            return self._density_scatter(plotobj, ax)
+
+        skipvars = ['plottype', 'plot_ax', 'x', 'y',
+                    'markersize', 'do_linear_regression',
+                    'linear_regression', 'density', 'channel']
+        inputs = self._get_inputs_dict(skipvars, plotobj)
+
+        # If the layer provided a scalar/array color via `c`, remove conflicting color keys
+        c_val = getattr(plotobj, 'c', None)
+        if c_val is not None:
+            inputs.pop('color', None)
+            inputs.pop('facecolor', None)
+            inputs.pop('facecolors', None)
+            cs = ax.scatter(plotobj.x, plotobj.y, s=plotobj.markersize, c=c_val, **inputs)
         else:
-            skip = ['plottype', 'plot_ax', 'x', 'y', 'markersize',
-                    'do_linear_regression', 'linear_regression', 'density', 'channel']
-            inputs = self._get_inputs_dict(skip, plotobj)
             cs = ax.scatter(plotobj.x, plotobj.y, s=plotobj.markersize, **inputs)
 
-        # optional regression overlay (not a mappable)
+        # Optional regression line
         if getattr(plotobj, "do_linear_regression", False):
             if len(plotobj.x) and len(plotobj.y):
                 y_pred, r_sq, intercept, slope = get_linear_regression(plotobj.x, plotobj.y)
                 label = f"y = {slope:.4f}x + {intercept:.4f}\nR\u00b2 : {r_sq:.4f}"
                 style = getattr(plotobj, "linear_regression", {})
-                if "color" not in style:
-                    point_color = getattr(plotobj, "color", None)
-                    if point_color is not None:
-                        style["color"] = point_color
+                if "color" not in style and hasattr(plotobj, "color"):
+                    style["color"] = plotobj.color
                 ax.plot(plotobj.x, y_pred, label=label, **style)
 
-        return cs  # PathCollection
+        return cs
 
     def _gridded(self, plotobj, ax):
         """

--- a/src/tests/plotting/test_adapters.py
+++ b/src/tests/plotting/test_adapters.py
@@ -1,0 +1,42 @@
+# src/tests/plotting/test_adapters.py
+import pytest
+
+from emcpy.plots import CreatePlot, CreateFigure
+from emcpy.plots.plots import LinePlot
+from emcpy.plots.adapters import get_adapter, register, _ADAPTERS
+
+
+def test_unknown_plottype_raises_keyerror():
+    with pytest.raises(KeyError, match="Unknown plottype"):
+        get_adapter("definitely_not_real")
+
+
+def test_registry_duplicate_plottype_rejected(monkeypatch):
+    # Make a temporary dummy adapter with a unique plottype.
+    @register
+    class _TmpAdapter:
+        plottype = "_tmp_kind"
+
+        def render(self, fig, st, layer):
+            return None
+
+    # Attempt to register again should error.
+    with pytest.raises(ValueError, match="already registered"):
+        @register
+        class _TmpAdapter2:
+            plottype = "_tmp_kind"
+
+            def render(self, fig, st, layer):
+                return None
+
+    # Cleanup (not strictly required, but keeps registry pristine if tests reorder)
+    _ADAPTERS.pop("_tmp_kind", None)
+
+
+def test_adapter_render_path_smoke(single_axes):
+    # Any built-in layer should resolve to a registered adapter and render.
+    lp = LinePlot([0, 1, 2], [0, 1, 4])
+    plot = CreatePlot(plot_layers=[lp])
+    fig, ax = single_axes(plot)
+    # Line plots don't produce "mappables" (colorbar sources), so last mappable is None.
+    assert fig._last_mappable_for_ax(ax) is None

--- a/src/tests/plotting/test_map_adapters.py
+++ b/src/tests/plotting/test_map_adapters.py
@@ -1,0 +1,124 @@
+# src/tests/plotting/test_map_adapters.py
+import numpy as np
+import pytest
+
+pytest.importorskip("cartopy")  # skip entire module if cartopy missing
+
+from matplotlib.collections import PathCollection, QuadMesh
+from matplotlib.contour import ContourSet
+
+from emcpy.plots import CreatePlot, CreateFigure
+from emcpy.plots.map_plots import MapScatter, MapGridded, MapContour, MapFilledContour
+
+
+def _basic_map_plot(layer):
+    plot = CreatePlot(plot_layers=[layer])
+    plot.projection = "plcarr"
+    plot.domain = "global"
+    return plot
+
+
+def test_map_scatter_with_data_mappable_and_colorbar(single_axes):
+    lat = np.linspace(10, 30, 20)
+    lon = np.linspace(-120, -90, 20)
+    data = np.linspace(200, 300, 20)
+    s = MapScatter(latitude=lat, longitude=lon, data=data)
+    s.cmap = "viridis"
+    s.markersize = 30
+
+    plot = _basic_map_plot(s)
+    plot.add_colorbar(label="units")
+
+    fig, ax = single_axes(plot)
+    m = fig._last_mappable_for_ax(ax)
+    assert isinstance(m, PathCollection)
+    assert len(fig.fig.axes) == 2
+
+
+def test_map_scatter_plain_points_no_colorbar(single_axes):
+    lat = np.linspace(35, 40, 5)
+    lon = np.linspace(-105, -95, 5)
+    s = MapScatter(latitude=lat, longitude=lon)
+    s.color = "tab:red"
+    s.markersize = 25
+
+    plot = _basic_map_plot(s)
+    plot.add_colorbar(label="ignored")
+    fig, ax = single_axes(plot)
+
+    assert len(fig.fig.axes) == 1
+
+
+def test_map_scatter_integer_field_requires_bounds():
+    lat = np.linspace(30, 40, 5)
+    lon = np.linspace(-100, -90, 5)
+    data = np.array([0, 1, 2, 3, 4])
+    s = MapScatter(latitude=lat, longitude=lon, data=data)
+    s.integer_field = True  # requires vmin/vmax
+
+    plot = _basic_map_plot(s)
+    plot.add_colorbar()
+
+    fig = CreateFigure(nrows=1, ncols=1)
+    fig.plot_list = [plot]
+    with pytest.raises(ValueError, match="vmin and vmax"):
+        fig.create_figure()
+
+
+def test_map_gridded_edges_ok_and_colorbar(single_axes):
+    lon = np.linspace(0, 360, 51)   # edges
+    lat = np.linspace(-90, 90, 51)  # edges
+    Z = np.random.RandomState(0).rand(50, 50)  # centers
+
+    g = MapGridded(lon, lat, Z)
+    g.cmap = "plasma"
+
+    plot = _basic_map_plot(g)
+    plot.add_colorbar(label="plasma")
+    fig, ax = single_axes(plot)
+
+    m = fig._last_mappable_for_ax(ax)
+    assert isinstance(m, QuadMesh)
+    assert len(fig.fig.axes) == 2
+
+
+def test_map_contour_returns_contourset_and_colorbar(single_axes):
+    lon = np.linspace(0, 360, 40)
+    lat = np.linspace(-60, 60, 30)
+    LON, LAT = np.meshgrid(lon, lat)
+    Z = np.cos(np.deg2rad(LAT)) * np.cos(2 * np.deg2rad(LON))
+
+    c = MapContour(LON, LAT, Z)
+    c.levels = np.linspace(-1.0, 1.0, 11)
+    c.colors = "k"
+
+    plot = _basic_map_plot(c)
+    plot.add_colorbar(label="contour")
+    fig, ax = single_axes(plot)
+
+    m = fig._last_mappable_for_ax(ax)
+    assert isinstance(m, ContourSet)
+    assert len(fig.fig.axes) == 2
+
+
+def test_map_filled_contour_single_cbar_last_subplot():
+    plots = []
+    for seed in (0, 1, 2, 3):
+        rng = np.random.RandomState(seed)
+        lon = np.linspace(0, 360, 40)
+        lat = np.linspace(-60, 60, 30)
+        LON, LAT = np.meshgrid(lon, lat)
+        Z = rng.rand(*LON.shape)
+
+        cf = MapFilledContour(LON, LAT, Z)
+        cf.cmap = "viridis"
+
+        p = _basic_map_plot(cf)
+        p.add_colorbar(orientation="horizontal", single_cbar=True, label="CF")
+        plots.append(p)
+
+    fig = CreateFigure(nrows=2, ncols=2, figsize=(8, 6))
+    fig.plot_list = plots
+    fig.create_figure()
+
+    assert len(fig.fig.axes) == 5  # 4 plots + 1 shared cbar

--- a/src/tests/plotting/test_mappables_colorbar.py
+++ b/src/tests/plotting/test_mappables_colorbar.py
@@ -1,0 +1,105 @@
+# src/tests/plotting/test_mappables_colorbar.py
+import numpy as np
+from matplotlib.collections import PathCollection, QuadMesh
+from matplotlib.contour import ContourSet
+
+from emcpy.plots import CreatePlot, CreateFigure
+from emcpy.plots.plots import Scatter, GriddedPlot, ContourPlot, FilledContourPlot, LinePlot
+
+
+def test_scatter_with_color_returns_mappable_and_colorbar(single_axes):
+    x = np.linspace(0, 1, 20)
+    y = np.linspace(0, 1, 20)
+    s = Scatter(x, y)
+    s.c = np.linspace(0, 1, len(x))  # emulate "c=" kw; Scatter stores as attribute → forwarded
+    s.cmap = "viridis"
+    s.markersize = 25
+
+    plot = CreatePlot(plot_layers=[s])
+    plot.add_colorbar(label="scatter cb")
+    fig, ax = single_axes(plot)
+
+    m = fig._last_mappable_for_ax(ax)
+    assert isinstance(m, PathCollection)
+    # one plot axes + one colorbar axes
+    assert len(fig.fig.axes) == 2
+
+
+def test_scatter_plain_points_no_colorbar(single_axes):
+    s = Scatter([0, 1, 2], [1, 2, 3])
+    s.color = "tab:red"  # no scalar-mapped 'c='
+    plot = CreatePlot(plot_layers=[s])
+    plot.add_colorbar(label="ignored")
+    fig, ax = single_axes(plot)
+
+    # No scalar mappable => no colorbar axes added.
+    assert len(fig.fig.axes) == 1
+
+
+def test_gridded_returns_quadmesh_and_colorbar(single_axes):
+    x = np.linspace(0, 1, 51)  # edges
+    y = np.linspace(0, 1, 51)  # edges
+    z = np.random.RandomState(0).rand(50, 50)  # centers
+    gp = GriddedPlot(x, y, z)
+    gp.cmap = "plasma"
+
+    plot = CreatePlot(plot_layers=[gp])
+    plot.add_colorbar(label="gridded cb")
+    fig, ax = single_axes(plot)
+
+    m = fig._last_mappable_for_ax(ax)
+    assert isinstance(m, QuadMesh)
+    assert len(fig.fig.axes) == 2
+
+
+def test_contour_and_contourf_last_mappable_wins(single_axes):
+    # Make a simple field
+    x = np.linspace(-3, 3, 40)
+    y = np.linspace(-3, 3, 30)
+    X, Y = np.meshgrid(x, y)
+    Z = np.cos(X) * np.sin(Y)
+
+    cf = FilledContourPlot(x, y, Z)
+    cf.cmap = "viridis"
+    c = ContourPlot(x, y, Z)
+    c.colors = "k"
+    c.levels = np.linspace(-1, 1, 11)
+
+    # Order matters: add contourf then contour → last mappable should be the contour set
+    plot = CreatePlot(plot_layers=[cf, c])
+    plot.add_colorbar(label="combo cb")
+    fig, ax = single_axes(plot)
+
+    m = fig._last_mappable_for_ax(ax)
+    assert isinstance(m, ContourSet)
+    assert len(fig.fig.axes) == 2
+
+
+def test_single_cbar_on_last_subplot_only():
+    plots = []
+    for seed in (0, 1, 2, 3):
+        rng = np.random.RandomState(seed)
+        x = np.linspace(0, 1, 40)
+        y = np.linspace(0, 1, 30)
+        X, Y = np.meshgrid(x, y)
+        Z = rng.rand(*Y.shape)
+
+        cf = FilledContourPlot(x, y, Z)
+        cf.cmap = "viridis"
+        p = CreatePlot(plot_layers=[cf])
+        p.add_colorbar(orientation="horizontal", single_cbar=True, label="CF")
+        plots.append(p)
+
+    fig = CreateFigure(nrows=2, ncols=2, figsize=(8, 6))
+    fig.plot_list = plots
+    fig.create_figure()
+
+    # 4 plot axes + 1 colorbar axes
+    assert len(fig.fig.axes) == 5
+
+
+def test_lineplot_produces_no_mappable(single_axes):
+    lp = LinePlot([0, 1, 2], [0, 1, 4])
+    plot = CreatePlot(plot_layers=[lp])
+    fig, ax = single_axes(plot)
+    assert fig._last_mappable_for_ax(ax) is None


### PR DESCRIPTION
## Summary
This PR decouples `CreateFigure` from plot-type conditionals by introducing a small Layer adapter/registry and adds input validation with actionable errors for core layers. It also hardens handling of optional dependencies (e.g., `seaborn` for `Density`) so missing extras don’t break unrelated plots.

### Goals:
- Make plotting extensible and safer.
- Produce clear, EMCPy-level error messages (rather than opaque Matplotlib traces).
- Keep all current visuals and user-facing APIs stable in v2.

## Why
Colorbar attachment depended on a mutable global (`self.cs`) and brittle “scan everything” fallbacks that could accidentally select non–colorbar-capable artists (e.g., `BarContainer`). This made multi-layer plots (gridded + lines, contourf + scatter, etc.) unpredictable. We also want a single, consistent path for renderers that works cleanly with the new adapter registry.

## What changed

1. All private renderers now return the artist they create.
- Map
  - `_map_scatter` → returns `PathCollection`
  - `_map_gridded` → returns `QuadMesh` (last tile if multiple)
  - `_map_contour` / `_map_filled_contour` → return `ContourSet`
- Cartesian
  - `_gridded` → `QuadMesh`
  - `_contour` / `_contourf` → `ContourSet`
  - `_scatter` / `_density_scatter` → `PathCollection`
  - `_lineplot` / `_skewt` → `Line2D`
  - `_histogram` → list of `Rectangle` patches
  - `_verticalline` / `_horizontalline` → `Line2D`
  - `_horizontalspan` → `PolyCollection`
  - `_barplot` / `_hbar` → `BarContainer`
  - `_boxandwhisker` → dict of artists

2. Eliminated `self.cs` everywhere.
Colorbar logic now uses _last_mappable_for_ax(ax) exclusively.

3. Safer colorbar selection.
- In `create_figure`, when an adapter returns a mappable, we store it in `self._ax_last_mappable[ax]`.
- `_last_mappable_for_ax` now:
  - Prefers the tracked value.
  - Falls back to newest `ScalarMappable` in `ax.collections` or `ax.images` (ignores containers like `BarContainer`).

4. Small guardrails & messages.
- `map_scatter` with `integer_field=True` now requires `vmin` and `vmax` (raises `ValueError` with a clear message).
- `boxplot`: if legacy `'labels'` kw appears, we raise with guidance to use `'tick_labels'` (Matplotlib ≥3.9).

## Behavior notes
- Colorbars now attach deterministically to the last `ScalarMappable` drawn on that axes (e.g., filled contour overlaid with lines → colorbar comes from the filled contour).
- Non-mappables (lines, bars, spans, box/whisker, hist patches) will never be chosen as a colorbar source.
- Regression lines added by `_scatter` remain overlays and do not interfere with colorbar selection.

## Backward compatibility
- Public API unchanged. Users still call `CreatePlot/CreateFigure` the same way.
- Internal change: renderers return artists; `self.cs` is no longer used. Any internal code that relied on `self.cs` has been updated (colorbar now reads `_last_mappable_for_ax`).

## Tests
- Existing plotting tests continue to pass with deterministic colorbar behavior.
- Colorbar tests that previously relied on `self.cs` now validate:
  - Per-axes vs single-figure colorbar placement.
  - That bar/hist layers do not produce colorbars.
  - That last-drawn mappable wins when multiple mappables exist.
 
## Contributor guidance (future layers)
- New `_foo` renderers must return the created artist.
- If the artist is a `ScalarMappable` (`QuadMesh`, `ContourSet`, `PathCollection`, `AxesImage`), returning it will automatically make it eligible for colorbars.
- Do not set any global like `self.cs`.

## Risk / Performance
- Low risk; changes are internal and exercised by tests.
- Negligible performance impact; storing a dict entry per-axes is O(1).

## Files of interest
- `emcpy/plots/create_plots.py`
  - Updated all `_map_*` and standard `_foo` renderers to return artists.
  - Removed `self.cs` usage.
  - `_last_mappable_for_ax` tightened to prefer tracked `ScalarMappable`, with safe fallback scan.
  - `create_figure` continues to record last mappable via the adapter return value.