### PR TITLE
Add new plot layers, helpers, renderers, adapters, tests, and optional `twinx` support

### DIFF
--- a/src/emcpy/plots/adapters.py
+++ b/src/emcpy/plots/adapters.py
@@ -273,7 +273,7 @@ class FillBetweenAdapter:
     plottype = "fill_between"
 
     def render(self, fig, st: AxState, layer):
-        x  = np.asarray(layer.x)
+        x = np.asarray(layer.x)
         y1 = np.asarray(layer.y1)
         y2 = np.asarray(layer.y2)
         if not (x.shape == y1.shape == y2.shape):

--- a/src/emcpy/plots/adapters.py
+++ b/src/emcpy/plots/adapters.py
@@ -268,6 +268,101 @@ class BoxWhiskerAdapter:
         return fig._boxandwhisker(layer, st.ax)
 
 
+@register
+class FillBetweenAdapter:
+    plottype = "fill_between"
+
+    def render(self, fig, st: AxState, layer):
+        x  = np.asarray(layer.x)
+        y1 = np.asarray(layer.y1)
+        y2 = np.asarray(layer.y2)
+        if not (x.shape == y1.shape == y2.shape):
+            raise ValueError(
+                "FillBetween: x, y1, and y2 must share the same shape; "
+                f"got x={x.shape}, y1={y1.shape}, y2={y2.shape}."
+            )
+        if layer.where is not None:
+            w = np.asarray(layer.where, dtype=bool)
+            if w.shape != x.shape:
+                raise ValueError(
+                    f"FillBetween: where mask must match x shape; got {w.shape} vs {x.shape}."
+                )
+        return fig._fillbetween(layer, st.ax)  # returns PolyCollection
+
+
+@register
+class ErrorBarAdapter:
+    plottype = "errorbar"
+
+    def render(self, fig, st: AxState, layer):
+        x = np.asarray(layer.x)
+        y = np.asarray(layer.y)
+        if x.shape != y.shape:
+            raise ValueError(
+                f"ErrorBar: x and y must have same shape; got {x.shape} vs {y.shape}."
+            )
+        # basic sanity: if tuple form for err, ensure length 2
+        for name in ("xerr", "yerr"):
+            err = getattr(layer, name, None)
+            if isinstance(err, tuple) and len(err) != 2:
+                raise ValueError(f"ErrorBar: {name} tuple must be (lower, upper).")
+        return fig._errorbar(layer, st.ax)  # returns ErrorbarContainer
+
+
+@register
+class ViolinAdapter:
+    plottype = "violin"
+
+    def render(self, fig, st: AxState, layer):
+        # allow any iterable of 1-D arrays; positions length (if given) must match
+        data = layer.data
+        try:
+            n = len(data)
+        except Exception:
+            raise ValueError("ViolinPlot: 'data' must be a sequence of 1-D arrays.")
+        if layer.positions is not None and len(layer.positions) != n:
+            raise ValueError(
+                f"ViolinPlot: positions length {len(layer.positions)} must match number of datasets {n}."
+            )
+        return fig._violin(layer, st.ax)  # returns dict of artists from violinplot
+
+
+@register
+class HexBinAdapter:
+    plottype = "hexbin"
+
+    def render(self, fig, st: AxState, layer):
+        x = np.asarray(layer.x)
+        y = np.asarray(layer.y)
+        if x.shape != y.shape:
+            raise ValueError(
+                f"HexBin: x and y must have same shape; got {x.shape} vs {y.shape}."
+            )
+        if layer.C is not None:
+            C = np.asarray(layer.C)
+            if C.shape != x.shape:
+                raise ValueError(
+                    f"HexBin: C must match x/y shape; got {C.shape} vs {x.shape}."
+                )
+        # gridsize may be int or (nx, ny); bins may be None/'log'/int — let MPL validate values
+        return fig._hexbin(layer, st.ax)  # returns PolyCollection (ScalarMappable)
+
+
+@register
+class Hist2DAdapter:
+    plottype = "hist2d"
+
+    def render(self, fig, st: AxState, layer):
+        x = np.asarray(layer.x)
+        y = np.asarray(layer.y)
+        if x.shape != y.shape:
+            raise ValueError(
+                f"Hist2D: x and y must have same shape; got {x.shape} vs {y.shape}."
+            )
+        # bins/range/norm validated by matplotlib; we pass through
+        return fig._hist2d(layer, st.ax)  # returns QuadMesh (ScalarMappable)
+
+
 # Map variants
 @register
 class MapScatterAdapter:

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -951,7 +951,7 @@ class CreateFigure:
 
         # Single, clean call (no fallback needed)
         bp = ax.boxplot(plotobj.data, **inputs)
-        return bp  # dict of 
+        return bp
 
     def _fillbetween(self, plotobj, ax):
         """

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -233,6 +233,55 @@ class CreatePlot:
 
         self.yscale = scale
 
+    def add_twinx(self, *layers):
+        """
+        Enable a secondary y-axis (twinx). Optionally pass one or more layers
+        that should be rendered on the right-hand axis.
+        """
+        if layers:
+            if not hasattr(self, "twin_layers"):
+                self.twin_layers = []
+            self.twin_layers.extend(layers)
+        self._use_twinx = True
+
+    def add_twin_ylabel(self, ylabel, labelpad=None, loc='center', **kwargs):
+        """
+        Y label for the secondary y-axis.
+        """
+        self.twin_ylabel = {
+            'ylabel': ylabel,
+            'labelpad': labelpad,
+            'loc': loc,
+            **kwargs
+        }
+
+    def set_twin_ylim(self, bottom=None, top=None):
+        self.twin_ylim = {'bottom': bottom, 'top': top}
+
+    def set_twin_yscale(self, scale):
+        valid_scales = ['log', 'linear', 'symlog', 'logit']
+        if scale not in valid_scales:
+            raise ValueError(f'requested scale {scale} is invalid. Valid '
+                             f'choices are: {" | ".join(valid_scales)}')
+        self.twin_yscale = scale
+
+    def set_twin_yticks(self, ticks=None, minor=False, formatter=None, date_format=None, clear_minor=True):
+        self.twin_yticks = {
+            "ticks": [] if ticks is None else ticks,
+            "minor": minor,
+            "formatter": formatter,
+            "date_format": date_format,
+            "clear_minor": clear_minor,
+        }
+
+    def set_twin_yticklabels(self, labels=None, minor=False, date_format=None, **kwargs):
+        self.twin_yticklabels = {
+            "labels": [] if labels is None else labels,
+            "minor": minor,
+            "date_format": date_format,
+            "kwargs": kwargs,
+        }
+
     def set_time_axis(self, major="month", minor="week", fmt="%b %Y", rotate=30, ha="right"):
         """
         Configure a time-aware x-axis with common defaults.
@@ -312,9 +361,6 @@ class CreateFigure:
         gs = gridspec.GridSpec(self.nrows, self.ncols)
         self.fig = plt.figure(figsize=self.figsize)
 
-        # Track the last colorbar-capable artist per axes
-        # (read by _last_mappable_for_ax in _plot_colorbar)
-
         for i, plot_obj in enumerate(self.plot_list):
             # --- Axes creation (map vs. normal) ---
             if hasattr(plot_obj, 'projection'):
@@ -338,7 +384,6 @@ class CreateFigure:
                         ax.yaxis.set_major_formatter(lat_formatter)
                 else:
                     ax.set_extent(self.domain.extent, ccrs.PlateCarree())
-
             else:
                 # Regular Axes (SkewT gets its projection)
                 plot_types = [x.plottype for x in plot_obj.plot_layers]
@@ -347,30 +392,61 @@ class CreateFigure:
                 else:
                     ax = self.fig.add_subplot(gs[i])
 
-            # --- Per-axes rendering state ---
+            # --- Optional secondary y-axis (twinx) ---
+            ax_twin = None
+            if getattr(plot_obj, "_use_twinx", False) or getattr(plot_obj, "twin_layers", None):
+                ax_twin = ax.twinx()
+
+            # --- Per-axes rendering state (primary) ---
             st = AxState(ax=ax)  # adapters append any mappables they create
 
-            # --- Render each layer via the adapter registry ---
+            # --- Render each primary-layer via the adapter registry ---
             for layer in plot_obj.plot_layers:
                 adapter = get_adapter(layer.plottype)  # raises KeyError if unknown
                 mappable = adapter.render(self, st, layer)
                 if mappable is not None:
                     st.mappables.append(mappable)
 
-            # --- Plot figure/axes features (title, labels, ticks, colorbar, etc.) ---
+            # --- Render twinx layers (if any) ---
+            if ax_twin is not None:
+                st_twin = AxState(ax=ax_twin)
+                for layer in getattr(plot_obj, "twin_layers", []):
+                    adapter = get_adapter(layer.plottype)
+                    mappable = adapter.render(self, st_twin, layer)
+                    if mappable is not None:
+                        st_twin.mappables.append(mappable)
+
+            # --- Plot figure/axes features (title, labels, ticks, colorbar, etc.) on primary ---
             for feat in vars(plot_obj).keys():
                 self._plot_features(plot_obj, feat, ax)
 
+            # Apply invert flags on primary
             self._apply_invert_flags(plot_obj, ax)
 
-            # --- Shared axes label hiding ---
+            # --- Shared axes label hiding (primary only) ---
             if self.sharex:
                 self._sharex(ax)
             if self.sharey:
                 self._sharey(ax)
 
-            # Final per-axes polish (e.g., time-axis formatting)
+            # Final per-axes polish (e.g., time-axis formatting) on primary
             self._finalize_axis(ax, plot_obj)
+
+            # --- Apply twin-axis specific features & finalize (if present) ---
+            if ax_twin is not None:
+                if hasattr(plot_obj, 'twin_ylabel'):
+                    self._plot_ylabel(ax_twin, plot_obj.twin_ylabel)
+                if hasattr(plot_obj, 'twin_ylim'):
+                    self._set_ylim(ax_twin, plot_obj.twin_ylim)
+                if hasattr(plot_obj, 'twin_yscale'):
+                    self._set_yscale(ax_twin, plot_obj.twin_yscale)
+                if hasattr(plot_obj, 'twin_yticks'):
+                    self._set_yticks(ax_twin, plot_obj.twin_yticks)
+                if hasattr(plot_obj, 'twin_yticklabels'):
+                    self._set_yticklabels(ax_twin, plot_obj.twin_yticklabels)
+
+                # No sharey logic for twin axis; x is shared implicitly
+                self._finalize_axis(ax_twin, plot_obj)
 
     def add_suptitle(self, text, **kwargs):
         """

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -233,6 +233,26 @@ class CreatePlot:
 
         self.yscale = scale
 
+    def set_time_axis(self, major="month", minor="week", fmt="%b %Y", rotate=30, ha="right"):
+        """
+        Configure a time-aware x-axis with common defaults.
+
+        Parameters
+        ----------
+        major : {"year","quarter","month","week","day","hour"}, default "month"
+        minor : {"quarter","month","week","day","hour",None}, default "week"
+        fmt   : str, date format passed to DateFormatter, default "%b %Y"
+        rotate: int, rotation for tick labels, default 30
+        ha    : str, horizontalalignment for tick labels, default "right"
+        """
+        self.time_axis = {
+            "major": major,
+            "minor": minor,
+            "fmt": fmt,
+            "rotate": rotate,
+            "ha": ha,
+        }
+
 
 class CreateFigure:
 
@@ -349,12 +369,37 @@ class CreateFigure:
             if self.sharey:
                 self._sharey(ax)
 
+            # Final per-axes polish (e.g., time-axis formatting)
+            self._finalize_axis(ax, plot_obj)
+
     def add_suptitle(self, text, **kwargs):
         """
         Add super title to figure. Useful for subplots.
         """
         if hasattr(self, 'fig'):
             self.fig.suptitle(text, **kwargs)
+
+    def add_shared_colorbar(self, mappable, axes, *, location: str = "right", label: str | None = None):
+        """
+        Add a single colorbar shared across the given axes (list of Axes).
+
+        Parameters
+        ----------
+        mappable : matplotlib.cm.ScalarMappable
+            The mappable returned by a plotting call (e.g., hexbin, pcolormesh).
+        axes : list[matplotlib.axes.Axes] or matplotlib.axes.Axes
+            Axes to which the colorbar should be associated.
+        location : {"right", "left", "top", "bottom"}, default "right"
+            Where to draw the colorbar relative to the axes grid.
+        label : str, optional
+            Colorbar label text.
+        """
+        if not isinstance(axes, (list, tuple)):
+            axes = [axes]
+        cbar = self.fig.colorbar(mappable, ax=axes, location=location)
+        if label:
+            cbar.set_label(label)
+        return cbar
 
     def plot_logo(self, loc, which='noaa/nws',
                   subplot_orientation='last', zoom=1, alpha=0.5):
@@ -830,7 +875,92 @@ class CreateFigure:
 
         # Single, clean call (no fallback needed)
         bp = ax.boxplot(plotobj.data, **inputs)
-        return bp  # dict of artists
+        return bp  # dict of 
+
+    def _fillbetween(self, plotobj, ax):
+        """
+        Render FillBetween layer.
+        """
+        skip = ['plottype', 'x', 'y1', 'y2']
+        inputs = self._get_inputs_dict(skip, plotobj)
+        poly = ax.fill_between(
+            plotobj.x, plotobj.y1, plotobj.y2,
+            **inputs
+        )
+        return poly  # PolyCollection (not a ScalarMappable)
+
+    def _errorbar(self, plotobj, ax):
+        """
+        Render ErrorBar layer.
+        """
+        skip = ['plottype', 'x', 'y']
+        inputs = self._get_inputs_dict(skip, plotobj)
+        cont = ax.errorbar(
+            plotobj.x, plotobj.y,
+            **inputs
+        )
+        return cont  # ErrorbarContainer (not necessarily a ScalarMappable)
+
+    def _violin(self, plotobj, ax):
+        """
+        Render ViolinPlot layer.
+        """
+        skip = ['plottype', 'data']
+        inputs = self._get_inputs_dict(skip, plotobj)
+
+        vio = ax.violinplot(
+            plotobj.data,
+            positions=inputs.pop('positions', None),
+            widths=inputs.pop('widths', None),
+            showmeans=inputs.pop('showmeans', False),
+            showmedians=inputs.pop('showmedians', True),
+            showextrema=inputs.pop('showextrema', True),
+        )
+
+        # Apply alpha to bodies if requested
+        alpha = inputs.pop('alpha', None)
+        if alpha is not None:
+            for b in vio.get('bodies', []):
+                b.set_alpha(alpha)
+
+        return vio  # dict of artists
+
+    def _hexbin(self, plotobj, ax):
+        """
+        Render HexBin layer.
+        """
+        skip = [
+            'plottype', 'x', 'y', 'C',
+            # colorbar-related fields are handled by CreatePlot.add_colorbar()
+            'colorbar', 'colorbar_label', 'colorbar_location'
+        ]
+        inputs = self._get_inputs_dict(skip, plotobj)
+        hb = ax.hexbin(
+            plotobj.x, plotobj.y, C=getattr(plotobj, 'C', None),
+            **inputs
+        )
+
+        return hb  # PolyCollection (ScalarMappable)
+
+    def _hist2d(self, plotobj, ax):
+        """
+        Render Hist2D layer.
+        """
+        skip = [
+            'plottype', 'x', 'y',
+            # colorbar-related fields are handled by CreatePlot.add_colorbar()
+            'colorbar', 'colorbar_label', 'colorbar_location'
+        ]
+        inputs = self._get_inputs_dict(skip, plotobj)
+        h, xedges, yedges, img = ax.hist2d(
+            plotobj.x, plotobj.y,
+            **inputs
+        )
+        alpha = getattr(plotobj, "alpha", None)
+        if alpha is not None:
+            img.set_alpha(alpha)
+
+        return img  # QuadMesh (ScalarMappable)
 
     def _get_inputs_dict(self, skipvars, plotobj):
         """
@@ -1220,6 +1350,53 @@ class CreateFigure:
         """
         if not self._is_first_col(ax):
             plt.setp(ax.get_yticklabels(), visible=False)
+
+    def _apply_time_axis(self, ax, opts: Optional[dict]):
+        """
+        Apply time-axis locators/formatters to `ax` using options set on the plot
+        via CreatePlot.set_time_axis(...). No-op if opts is None.
+        """
+        if not opts:
+            return
+
+        major_map = {
+            "year": mdates.YearLocator(),
+            "quarter": mdates.MonthLocator(bymonth=[1, 4, 7, 10]),
+            "month": mdates.MonthLocator(),
+            "week": mdates.WeekdayLocator(),  # Monday default
+            "day": mdates.DayLocator(),
+            "hour": mdates.HourLocator(),
+        }
+        minor_map = {
+            "quarter": mdates.MonthLocator(bymonth=[1, 4, 7, 10]),
+            "month": mdates.MonthLocator(),
+            "week": mdates.WeekdayLocator(),
+            "day": mdates.DayLocator(),
+            "hour": mdates.HourLocator(),
+            None: None,
+        }
+
+        major = major_map.get(opts.get("major", "month"), mdates.MonthLocator())
+        minor = minor_map.get(opts.get("minor", "week"))
+
+        ax.xaxis.set_major_locator(major)
+        if minor is not None:
+            ax.xaxis.set_minor_locator(minor)
+
+        ax.xaxis.set_major_formatter(mdates.DateFormatter(opts.get("fmt", "%b %Y")))
+        rotate = int(opts.get("rotate", 30))
+        ha = opts.get("ha", "right")
+
+        for lab in ax.get_xticklabels():
+            lab.set_rotation(rotate)
+            lab.set_ha(ha)
+
+    def _finalize_axis(self, ax, plot_obj):
+        """
+        Final per-axes adjustments that should happen after features,
+        inversion, and shared-label handling.
+        """
+        self._apply_time_axis(ax, getattr(plot_obj, "time_axis", None))
 
     def _subplot_spec(self, ax):
         """

--- a/src/emcpy/plots/plots.py
+++ b/src/emcpy/plots/plots.py
@@ -6,11 +6,13 @@ __all__ = [
     'VerticalLine', 'HorizontalLine', 'HorizontalSpan',
     'BarPlot', 'HorizontalBar', 'SkewT',
     'GriddedPlot', 'ContourPlot', 'FilledContourPlot',
-    'BoxandWhiskerPlot'
+    'BoxandWhiskerPlot', 'FillBetween', 'ErrorBar',
+    'ViolinPlot', 'HexBin', 'Hist2D',
 ]
 
 
 class Scatter:
+
     def __init__(self, x, y):
         """
         Scatter plot layer.
@@ -418,3 +420,163 @@ class BoxandWhiskerPlot:
         self.autorange = False
         self.meanline = False
         self.zorder = None
+
+
+class FillBetween:
+
+    def __init__(self, x, y1, y2):
+        """
+        Area fill between y1 and y2 across x.
+
+        Args:
+            x  : array-like
+            y1 : array-like
+            y2 : array-like
+        """
+        super().__init__()
+        self.plottype = 'fill_between'
+
+        self.x = x
+        self.y1 = y1
+        self.y2 = y2
+
+        self.where = None          # optional boolean mask
+        self.color = 'tab:blue'
+        self.alpha = None
+        self.label = None
+        self.linewidth = None
+        self.linestyle = None
+        self.step = None           # {'pre','post','mid'} or None
+        self.zorder = None
+
+
+class ErrorBar:
+
+    def __init__(self, x, y):
+        """
+        Error bar layer.
+
+        Args:
+            x : array-like
+            y : array-like
+        """
+        super().__init__()
+        self.plottype = 'errorbar'
+
+        self.x = x
+        self.y = y
+
+        # errors
+        self.yerr = None           # float, array-like, or (lower, upper)
+        self.xerr = None           # float, array-like, or (lower, upper)
+
+        # style / markers
+        self.fmt = 'o'
+        self.color = 'darkgray'
+        self.alpha = None
+        self.markersize = 5
+        self.ecolor = 'black'
+        self.elinewidth = 1.0
+        self.capthick = None
+        self.capsize = 0.0
+        self.barsabove = False
+        self.zorder = None
+
+        # label defaults to non-NaN x count (consistent with Scatter/Histogram)
+        self.label = f'n={np.count_nonzero(~np.isnan(x))}'
+
+
+class ViolinPlot:
+
+    def __init__(self, data):
+        """
+        Violin plot layer for 1-D distributions.
+
+        Args:
+            data : sequence of 1-D array-like datasets
+        """
+        super().__init__()
+        self.plottype = 'violin'
+
+        self.data = data
+
+        self.positions = None      # sequence of x positions
+        self.widths = 0.8
+        self.showmeans = False
+        self.showmedians = True
+        self.showextrema = True
+        self.alpha = None
+        self.zorder = None
+
+
+class HexBin:
+
+    def __init__(self, x, y, C=None):
+        """
+        Hexagonal binning layer.
+
+        Args:
+            x : array-like
+            y : array-like
+            C : optional array-like of values to reduce within bins
+        """
+        super().__init__()
+        self.plottype = 'hexbin'
+
+        self.x = x
+        self.y = y
+        self.C = C
+
+        self.gridsize = 30                      # int or (nx, ny)
+        self.reduce_C_function = None           # e.g., np.mean
+        self.extent = None                      # (xmin, xmax, ymin, ymax)
+        self.bins = None                        # None, 'log', or int
+        self.mincnt = None
+        self.linewidths = None
+        self.cmap = 'viridis'
+        self.norm = None                        # optional matplotlib Normalize
+        self.vmin = None
+        self.vmax = None
+        self.alpha = None
+        self.zorder = None
+        self.label = None
+
+        # colorbar controls
+        self.colorbar = False
+        self.colorbar_label = None
+        self.colorbar_location = 'right'
+
+
+class Hist2D:
+
+    def __init__(self, x, y):
+        """
+        2D histogram layer.
+
+        Args:
+            x : array-like
+            y : array-like
+        """
+        super().__init__()
+        self.plottype = 'hist2d'
+
+        self.x = x
+        self.y = y
+
+        self.bins = 30                            # int, (nx, ny), or (xbins, ybins)
+        self.range = None                         # ((xmin, xmax), (ymin, ymax))
+        self.density = False
+        self.cmap = 'viridis'
+        self.norm = None                          # optional matplotlib Normalize
+        self.vmin = None
+        self.vmax = None
+        self.cmin = None
+        self.cmax = None
+        self.alpha = None
+        self.zorder = None
+        self.label = None
+
+        # colorbar controls
+        self.colorbar = True
+        self.colorbar_label = None
+        self.colorbar_location = 'right'

--- a/src/emcpy/plots/plots.py
+++ b/src/emcpy/plots/plots.py
@@ -12,7 +12,6 @@ __all__ = [
 
 
 class Scatter:
-
     def __init__(self, x, y):
         """
         Scatter plot layer.
@@ -65,7 +64,6 @@ class Scatter:
 
 
 class Histogram:
-
     def __init__(self, data):
         """
         Constructor for Histogram.
@@ -96,7 +94,6 @@ class Histogram:
 
 
 class Density():
-
     def __init__(self, data):
         """
         Constructor for Density.
@@ -132,7 +129,6 @@ class Density():
 
 
 class LinePlot:
-
     def __init__(self, x, y):
         """
         Constructor for LinePlot.
@@ -156,7 +152,6 @@ class LinePlot:
 
 
 class GriddedPlot:
-
     def __init__(self, x, y, z):
         """
         Constructor for GriddedPlot.
@@ -183,7 +178,6 @@ class GriddedPlot:
 
 
 class ContourPlot:
-
     def __init__(self, x, y, z):
         """
         Constructor for ContourPlot.
@@ -215,7 +209,6 @@ class ContourPlot:
 
 
 class FilledContourPlot:
-
     def __init__(self, x, y, z):
         """
         Constructor for FilledContourPlot.
@@ -246,7 +239,6 @@ class FilledContourPlot:
 
 
 class VerticalLine:
-
     def __init__(self, x):
         """
         Constructor for VerticalLine
@@ -267,7 +259,6 @@ class VerticalLine:
 
 
 class HorizontalLine:
-
     def __init__(self, y):
         """
         Constructor for HorizontalLine
@@ -288,7 +279,6 @@ class HorizontalLine:
 
 
 class HorizontalSpan:
-
     def __init__(self, ymin, ymax):
         """
         Constructor for HorizontalSpan
@@ -308,7 +298,6 @@ class HorizontalSpan:
 
 
 class BarPlot:
-
     def __init__(self, x, height):
         """
         Constructor for BarPlot.
@@ -339,7 +328,6 @@ class BarPlot:
 
 
 class HorizontalBar:
-
     def __init__(self, y, width):
         """
         Constructor to create a horizontal bar plot.
@@ -370,7 +358,6 @@ class HorizontalBar:
 
 
 class SkewT:
-
     def __init__(self, x, y):
         """
         Constructor to create a Skew T plot.
@@ -395,7 +382,6 @@ class SkewT:
 
 
 class BoxandWhiskerPlot:
-
     def __init__(self, data):
 
         self.plottype = 'boxandwhisker'
@@ -423,7 +409,6 @@ class BoxandWhiskerPlot:
 
 
 class FillBetween:
-
     def __init__(self, x, y1, y2):
         """
         Area fill between y1 and y2 across x.
@@ -451,7 +436,6 @@ class FillBetween:
 
 
 class ErrorBar:
-
     def __init__(self, x, y):
         """
         Error bar layer.
@@ -487,7 +471,6 @@ class ErrorBar:
 
 
 class ViolinPlot:
-
     def __init__(self, data):
         """
         Violin plot layer for 1-D distributions.
@@ -510,7 +493,6 @@ class ViolinPlot:
 
 
 class HexBin:
-
     def __init__(self, x, y, C=None):
         """
         Hexagonal binning layer.
@@ -548,7 +530,6 @@ class HexBin:
 
 
 class Hist2D:
-
     def __init__(self, x, y):
         """
         2D histogram layer.

--- a/src/tests/plotting/test_layers_basic.py
+++ b/src/tests/plotting/test_layers_basic.py
@@ -317,9 +317,6 @@ def test_skewt_projection(single_axes):
     _, ax = single_axes(plot)
     assert "SkewXAxes" in ax.__class__.__name__
 
-# -------------------------
-# New layer smoke tests
-# -------------------------
 
 def test_fillbetween_smoke():
     x = np.linspace(0, 2 * np.pi, 64)
@@ -430,6 +427,7 @@ def test_time_axis_helper_applies_dateformatter_and_rotation():
 
     plt.close(f.fig)
 
+
 def test_twinx_smoke():
     # Primary series
     xs = np.linspace(0, 10, 200)
@@ -454,4 +452,3 @@ def test_twinx_smoke():
     assert "Right Axis" in [ax.get_ylabel() for ax in f.fig.axes]
 
     plt.close(f.fig)
-

--- a/src/tests/plotting/test_layers_basic.py
+++ b/src/tests/plotting/test_layers_basic.py
@@ -318,10 +318,12 @@ def test_skewt_projection(single_axes):
     assert "SkewXAxes" in ax.__class__.__name__
 
 
-def test_fillbetween_smoke():
+def test_fillbetween():
     x = np.linspace(0, 2 * np.pi, 64)
     y = np.sin(x)
-    layer = FillBetween(x=x, y1=y - 0.3, y2=y + 0.3, alpha=0.25, color="C0")
+    layer = FillBetween(x=x, y1=y - 0.3, y2=y + 0.3)
+    layer.alpha = 0.25
+    layer.color = "C0"
 
     p = CreatePlot(plot_layers=[layer])
     f = CreateFigure(nrows=1, ncols=1)
@@ -330,7 +332,7 @@ def test_fillbetween_smoke():
     plt.close(f.fig)
 
 
-def test_errorbar_smoke():
+def test_errorbar():
     x = np.arange(10)
     y = 0.5 * x
     layer = ErrorBar(x=x, y=y)
@@ -344,7 +346,7 @@ def test_errorbar_smoke():
     plt.close(f.fig)
 
 
-def test_violin_smoke():
+def test_violin():
     rng = np.random.default_rng(0)
     data = [rng.normal(loc=mu, scale=0.5, size=120) for mu in (0.0, 1.0, 2.0)]
     layer = ViolinPlot(data=data)
@@ -359,11 +361,13 @@ def test_violin_smoke():
     plt.close(f.fig)
 
 
-def test_hexbin_with_per_axes_colorbar_smoke():
+def test_hexbin_with_per_axes_colorbar():
     rng = np.random.default_rng(1)
     x = rng.standard_normal(1000)
     y = rng.standard_normal(1000)
-    layer = HexBin(x=x, y=y, gridsize=25, cmap="viridis")
+    layer = HexBin(x=x, y=y)
+    layer.gridsize = 25
+    layer.cmap = "viridis"
 
     p = CreatePlot(plot_layers=[layer])
     # Ask framework to add a per-axes colorbar using the last mappable
@@ -375,13 +379,21 @@ def test_hexbin_with_per_axes_colorbar_smoke():
     plt.close(f.fig)
 
 
-def test_hist2d_shared_colorbar_smoke():
+def test_hist2d_shared_colorbar():
     rng = np.random.default_rng(2)
     x = rng.standard_normal(1200)
     y = rng.standard_normal(1200)
 
-    p1 = CreatePlot(plot_layers=[Hist2D(x=x, y=y, bins=30, cmap="magma")])
-    p2 = CreatePlot(plot_layers=[Hist2D(x=0.5 * x, y=0.5 * y, bins=20, cmap="magma")])
+    l1 = Hist2D(x=x, y=y)
+    l1.bins = 30
+    l1.cmap = "magma"
+
+    l2 = Hist2D(x=0.5 * x, y=0.5 * y)
+    l2.bins = 20
+    l2.cmap = "magma"
+
+    p1 = CreatePlot(plot_layers=[l1])
+    p2 = CreatePlot(plot_layers=[l2])
 
     f = CreateFigure(nrows=1, ncols=2)
     f.plot_list = [p1, p2]
@@ -389,7 +401,6 @@ def test_hist2d_shared_colorbar_smoke():
 
     # Grab the QuadMesh (ScalarMappable) from the second axes and attach a shared colorbar
     ax1, ax2 = f.fig.axes[:2]
-    # hist2d adds a QuadMesh to collections
     assert len(ax2.collections) > 0
     mappable = ax2.collections[-1]
     f.add_shared_colorbar(mappable, [ax1, ax2], location="right", label="density")
@@ -399,6 +410,7 @@ def test_hist2d_shared_colorbar_smoke():
 # -------------------------
 # Helper behavior tests
 # -------------------------
+
 
 def test_time_axis_helper_applies_dateformatter_and_rotation():
     # Make a simple time series across several months
@@ -422,19 +434,18 @@ def test_time_axis_helper_applies_dateformatter_and_rotation():
     # If labels exist, they should be rotated ~15 degrees
     labs = ax.get_xticklabels()
     if labs:
-        # rotation may be float; compare numerically
         assert pytest.approx(labs[0].get_rotation(), rel=0, abs=0.5) == 15
 
     plt.close(f.fig)
 
 
-def test_twinx_smoke():
+def test_twinx():
     # Primary series
     xs = np.linspace(0, 10, 200)
     y1 = np.sin(xs)
 
     # Secondary series on different scale
-    y2 = 50 + 20*np.cos(xs)
+    y2 = 50 + 20 * np.cos(xs)
 
     p = CreatePlot(plot_layers=[LinePlot(xs, y1)])
     # Add secondary axis content

--- a/src/tests/plotting/test_layers_basic.py
+++ b/src/tests/plotting/test_layers_basic.py
@@ -429,3 +429,29 @@ def test_time_axis_helper_applies_dateformatter_and_rotation():
         assert pytest.approx(labs[0].get_rotation(), rel=0, abs=0.5) == 15
 
     plt.close(f.fig)
+
+def test_twinx_smoke():
+    # Primary series
+    xs = np.linspace(0, 10, 200)
+    y1 = np.sin(xs)
+
+    # Secondary series on different scale
+    y2 = 50 + 20*np.cos(xs)
+
+    p = CreatePlot(plot_layers=[LinePlot(xs, y1)])
+    # Add secondary axis content
+    p.add_twinx(LinePlot(xs, y2))
+    p.add_twin_ylabel("Right Axis")
+    p.set_twin_ylim(0, 100)
+
+    f = CreateFigure()
+    f.plot_list = [p]
+    f.create_figure()
+
+    # We should have at least 2 Axes (primary + twinx)
+    assert len(f.fig.axes) >= 2
+    # One of them should carry the right-axis label we set
+    assert "Right Axis" in [ax.get_ylabel() for ax in f.fig.axes]
+
+    plt.close(f.fig)
+

--- a/src/tests/plotting/test_layers_basic.py
+++ b/src/tests/plotting/test_layers_basic.py
@@ -1,13 +1,18 @@
 # tests/plotting/test_layers_basic.py
+import matplotlib
+matplotlib.use("Agg")
 import numpy as np
 import pytest
-import matplotlib
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import datetime as dt
 from io import StringIO
 
 from emcpy.plots.plots import (
     LinePlot, Histogram, Density, Scatter, BarPlot, HorizontalBar,
     GriddedPlot, ContourPlot, FilledContourPlot, BoxandWhiskerPlot,
-    HorizontalSpan, SkewT
+    HorizontalSpan, SkewT, FillBetween, ErrorBar, ViolinPlot,
+    HexBin, Hist2D, LinePlot,
 )
 from emcpy.plots.create_plots import CreatePlot, CreateFigure
 
@@ -311,3 +316,116 @@ def test_skewt_projection(single_axes):
     plot = CreatePlot(plot_layers=[tplot, tdplot])
     _, ax = single_axes(plot)
     assert "SkewXAxes" in ax.__class__.__name__
+
+# -------------------------
+# New layer smoke tests
+# -------------------------
+
+def test_fillbetween_smoke():
+    x = np.linspace(0, 2 * np.pi, 64)
+    y = np.sin(x)
+    layer = FillBetween(x=x, y1=y - 0.3, y2=y + 0.3, alpha=0.25, color="C0")
+
+    p = CreatePlot(plot_layers=[layer])
+    f = CreateFigure(nrows=1, ncols=1)
+    f.plot_list = [p]
+    f.create_figure()
+    plt.close(f.fig)
+
+
+def test_errorbar_smoke():
+    x = np.arange(10)
+    y = 0.5 * x
+    layer = ErrorBar(x=x, y=y)
+    layer.yerr = 0.2
+    layer.capsize = 2
+
+    p = CreatePlot(plot_layers=[layer])
+    f = CreateFigure()
+    f.plot_list = [p]
+    f.create_figure()
+    plt.close(f.fig)
+
+
+def test_violin_smoke():
+    rng = np.random.default_rng(0)
+    data = [rng.normal(loc=mu, scale=0.5, size=120) for mu in (0.0, 1.0, 2.0)]
+    layer = ViolinPlot(data=data)
+    layer.widths = 0.8
+    layer.showmedians = True
+    # No legend proxy expected/required
+
+    p = CreatePlot(plot_layers=[layer])
+    f = CreateFigure()
+    f.plot_list = [p]
+    f.create_figure()
+    plt.close(f.fig)
+
+
+def test_hexbin_with_per_axes_colorbar_smoke():
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal(1000)
+    y = rng.standard_normal(1000)
+    layer = HexBin(x=x, y=y, gridsize=25, cmap="viridis")
+
+    p = CreatePlot(plot_layers=[layer])
+    # Ask framework to add a per-axes colorbar using the last mappable
+    p.add_colorbar(label="counts", single_cbar=False, orientation="vertical")
+
+    f = CreateFigure()
+    f.plot_list = [p]
+    f.create_figure()
+    plt.close(f.fig)
+
+
+def test_hist2d_shared_colorbar_smoke():
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal(1200)
+    y = rng.standard_normal(1200)
+
+    p1 = CreatePlot(plot_layers=[Hist2D(x=x, y=y, bins=30, cmap="magma")])
+    p2 = CreatePlot(plot_layers=[Hist2D(x=0.5 * x, y=0.5 * y, bins=20, cmap="magma")])
+
+    f = CreateFigure(nrows=1, ncols=2)
+    f.plot_list = [p1, p2]
+    f.create_figure()
+
+    # Grab the QuadMesh (ScalarMappable) from the second axes and attach a shared colorbar
+    ax1, ax2 = f.fig.axes[:2]
+    # hist2d adds a QuadMesh to collections
+    assert len(ax2.collections) > 0
+    mappable = ax2.collections[-1]
+    f.add_shared_colorbar(mappable, [ax1, ax2], location="right", label="density")
+    plt.close(f.fig)
+
+
+# -------------------------
+# Helper behavior tests
+# -------------------------
+
+def test_time_axis_helper_applies_dateformatter_and_rotation():
+    # Make a simple time series across several months
+    start = dt.datetime(2024, 1, 1)
+    xs = [start + dt.timedelta(days=int(d)) for d in np.linspace(0, 180, 40)]
+    ys = np.sin(np.linspace(0, 6 * np.pi, len(xs)))
+
+    layer = LinePlot(xs, ys)
+    p = CreatePlot(plot_layers=[layer])
+    # Request monthly majors, weekly minors, custom fmt and rotation
+    p.set_time_axis(major="month", minor="week", fmt="%b %Y", rotate=15, ha="right")
+
+    f = CreateFigure()
+    f.plot_list = [p]
+    f.create_figure()
+
+    ax = f.fig.axes[0]
+    # Major formatter should be a DateFormatter
+    assert isinstance(ax.xaxis.get_major_formatter(), mdates.DateFormatter)
+
+    # If labels exist, they should be rotated ~15 degrees
+    labs = ax.get_xticklabels()
+    if labs:
+        # rotation may be float; compare numerically
+        assert pytest.approx(labs[0].get_rotation(), rel=0, abs=0.5) == 15
+
+    plt.close(f.fig)

--- a/src/tests/plotting/test_layers_basic.py
+++ b/src/tests/plotting/test_layers_basic.py
@@ -12,7 +12,7 @@ from emcpy.plots.plots import (
     LinePlot, Histogram, Density, Scatter, BarPlot, HorizontalBar,
     GriddedPlot, ContourPlot, FilledContourPlot, BoxandWhiskerPlot,
     HorizontalSpan, SkewT, FillBetween, ErrorBar, ViolinPlot,
-    HexBin, Hist2D, LinePlot,
+    HexBin, Hist2D,
 )
 from emcpy.plots.create_plots import CreatePlot, CreateFigure
 


### PR DESCRIPTION
This PR adds several frequently used plotting primitives to EMCPy, plus helpers for shared colorbars and time-formatted axes. It also introduces an optional secondary y-axis (`twinx`) path that integrates with the existing adapter/renderer architecture.
## Summary of changes
### New plot layers (`src/emcpy/plots/plots.py`)
Implemented in the same style as existing layers (simple classes, `plottype` string, public attributes with with sensible defaults):
- `FillBetween` `plottype='fill_between'`
- `ErrorBar` `plottype='errorbar'`
- `ViolinPlot` `plottype='violin'`
- `HexBin` `plottype='hexbin'`
- `Hist2D` `plottype='hist2d'`

**Notes**
- Attributes mirror Matplotlib where practical, so renderers can pass through kwargs directly.
- `ViolinPlot` intentionally **does not** force a legend label (Matplotlib s `violinplot` doesn’t label bodies by default; we avoid proxy hacks).
### New helpers
- **Time axis formatting** (per plot / per axes):
 `CreatePlot.set_time_axis(major="month", minor="week", fmt="%b %Y", rotate=30, ha="right")`
 Applied during finalize for each axes via `CreateFigure._finalize_axis(...)`.
- **Shared colorbar** (across axes in a figure):
 `CreateFigure.add_shared_colorbar(mappable, axes, *, location="right", label=None)`
**Design:** `add_shared_colorbar` lives on **`CreateFigure`** (owns `self.fig`), not `CreatePlot`.
---
### New renderers (`src/emcpy/plots/create_plots.py`)
Private methods added, called by adapters:
- `_fillbetween(plotobj, ax)` returns `PolyCollection`
- `_errorbar(plotobj, ax)` returns `ErrorbarContainer`
- `_violin(plotobj, ax)` returns dict of artists from `ax.violinplot(...)` (no legend proxy)
- `_hexbin(plotobj, ax)` returns `PolyCollection` (ScalarMappable)
- `_hist2d(plotobj, ax)` returns `QuadMesh` (ScalarMappable)
**Finalize hook:** `CreateFigure.create_figure()` now calls `_finalize_axis(ax, plot_obj)` per subplot to apply time-axis formatting after features/ticks/scales/limits are set.
### Adapters (`src/emcpy/plots/adapters.py`)
New adapters registered with shape/argument validation and dispatch to the new renderers:
- `FillBetweenAdapter` `"fill_between"` `_fillbetween`
- `ErrorBarAdapter` `"errorbar"` `_errorbar`
- `ViolinAdapter` `"violin"` `_violin`
- `HexBinAdapter` `"hexbin"` `_hexbin`
- `Hist2DAdapter` `"hist2d"` `_hist2d`
**Validation highlights**
- `FillBetween`: `x`, `y1`, `y2` shape checks; optional `where` mask length check.
- `ErrorBar`: `x`/`y` shapes; tuple form for `xerr`/`yerr` validated.
- `Violin`: `positions` length matches number of datasets.
- `HexBin`/`Hist2D`: `x`/`y` shapes; `C` matches `x`/`y` if provided.
---
### Optional secondary y-axis (`twinx`) support
**CreatePlot API**
- `add_twinx(*layers)` enable a right-hand y-axis and optionally attach layers to it.
- `add_twin_ylabel(ylabel, ...)`
- `set_twin_ylim(bottom=None, top=None)`
- `set_twin_yscale(scale)` (valid: `log|linear|symlog|logit`)
- `set_twin_yticks(...)` and `set_twin_yticklabels(...)`
**CreateFigure integration**
- `create_figure()` creates `ax.twinx()` when requested, renders twin layers via the same adapter system, applies twin-specific label/limits/scale/ticks helpers, and finalizes the twin axis (no x-formatting; x is shared with primary).
**Colorbars/legends:** same semantics as before. For a colorbar tied to a twinx mappable across multiple axes, use CreateFigure.add_shared_colorbar(...) after create_figure().
## Tests (`tests/plots/test_layers_basic.py`)
Agg-backend smoke tests added:
- `test_fillbetween_smoke`
- `test_errorbar_smoke`
- `test_violin_smoke` (no legend requirement)
- `test_hexbin_with_per_axes_colorbar_smoke` (per-axes colorbar via framework)
- `test_hist2d_shared_colorbar_smoke` (uses `CreateFigure.add_shared_colorbar`)
- `test_time_axis_helper_applies_dateformatter_and_rotation`
- `test_twinx_smoke` (secondary y-axis end-to-end)
**Run**
```bash
pytest -q tests/plots/test_layers_basic.py
```
---
## Usage snippets
**FillBetween + time axis**
```python
from emcpy.plots.create_plots import CreatePlot, CreateFigure
from emcpy.plots.plots import FillBetween, LinePlot
import numpy as np, datetime as dt
xs = [dt.datetime(2024,1,1) + dt.timedelta(days=d) for d in range(0, 120, 3)]
y = np.sin(np.linspace(0, 6*np.pi, len(xs)))
band = FillBetween(xs, y-0.2, y+0.2); band.alpha = 0.25
p = CreatePlot([band, LinePlot(xs, y)])
p.set_time_axis(major="month", minor="week", fmt="%b %Y", rotate=15)
f = CreateFigure()
f.plot_list = [p]
f.create_figure()
```
**Twinx**
```python
from emcpy.plots.plots import LinePlot
xs = np.linspace(0, 10, 200)
p = CreatePlot([LinePlot(xs, np.sin(xs))])
p.add_twinx(LinePlot(xs, 50 + 20*np.cos(xs)))
p.add_twin_ylabel("Right Axis")
```
**Shared colorbar**
```python
f = CreateFigure(nrows=1, ncols=2)
f.plot_list = [p1, p2]
f.create_figure()
mappable = f.fig.axes[1].collections[-1] # e.g., QuadMesh from hist2d
f.add_shared_colorbar(mappable, f.fig.axes[:2], location="right", label="density")
```
---
## Backward compatibility
- No breaking changes to existing layers or rendering flow.
- `add_shared_colorbar` is new and lives on `CreateFigure`.
- `ViolinPlot` does not auto-add legend entries (intentional).
- `add_twinx` is new; an alias `add_to_twinx` is provided.
---
## Implementation notes
- Renderers return Matplotlib artists compatible with existing colorbar logic (last valid mappable per axes- Time axis formatting is applied in `_finalize_axis` to avoid later features clobbering formatters/locato- Adapters centralize validation and keep renderers thin.
---
## Future work (optional)
- Gallery examples for each new layer and a short Using `set_time_axis` recipe.
- Optional `twin_colorbar(...)` convenience targeting the twin axis.
- `norm` support on `HexBin`/`Hist2D` layers (e.g., `LogNorm`) as a first-class attribute.
- `set_time_axis` parity for y (time on y-axis).
---
