### PR TITLE
Add HeatMap to plotting types

### DIFF
--- a/galleries/examples/gridded_plots/heatmap_basic.py
+++ b/galleries/examples/gridded_plots/heatmap_basic.py
@@ -1,0 +1,40 @@
+"""
+Heatmap
+=======
+
+Categorical heatmap with a diverging colormap, cell
+annotations, and missing-data masking.
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+
+from emcpy.plots.plots import HeatMap
+from emcpy.plots.create_plots import CreatePlot, CreateFigure
+
+cycles = ["00Z", "06Z", "12Z", "18Z", "00Z+1", "06Z+1"]
+variables = ["TEMP", "UWND", "VWND", "SPFH", "PRES"]
+
+rng = np.random.default_rng(42)
+data = rng.normal(0, 1.5, size=(len(variables), len(cycles)))
+data[1, 3] = np.nan   # simulate a missing/quarantined cycle
+data[4, :2] = np.nan  # variable not yet reporting at start of window
+
+p = CreatePlot()
+hm = HeatMap(cycles, variables, data)
+hm.cmap = "RdBu_r"
+hm.center = 0.0
+hm.annotate = True
+hm.annotate_fmt = "{:.2f}"
+hm.mask_color = "lightgray"
+p.plot_layers = [hm]
+
+p.add_title("Observation Bias by Variable and Cycle")
+p.add_xlabel("Cycle")
+p.add_ylabel("Variable")
+p.add_colorbar(label="O-B bias")
+
+fig = CreateFigure(nrows=1, ncols=1, figsize=(8, 4.5))
+fig.plot_list = [p]
+fig.create_figure()
+fig.tight_layout()
+plt.show()

--- a/galleries/plot_types/gridded/heatmap.py
+++ b/galleries/plot_types/gridded/heatmap.py
@@ -1,0 +1,55 @@
+"""
+Heatmap
+-------
+
+Below is an example of how to plot a categorical heatmap
+using EMCPy's plotting method.
+
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from emcpy.plots.plots import HeatMap
+from emcpy.plots.create_plots import CreatePlot, CreateFigure
+
+
+def main():
+    # Create heatmap plot
+
+    # Grab sample data
+    x, y, data = _getHeatmapData()
+
+    # Create heatmap object
+    hm = HeatMap(x, y, data)
+    hm.cmap = 'viridis'
+
+    # Create plot object and add features
+    plot1 = CreatePlot()
+    plot1.plot_layers = [hm]
+    plot1.add_xlabel(xlabel='X Axis Label')
+    plot1.add_ylabel(ylabel='Y Axis Label')
+    plot1.add_title('Heatmap')
+    plot1.add_colorbar(orientation='vertical')
+
+    # Create figure
+    fig = CreateFigure()
+    fig.plot_list = [plot1]
+    fig.create_figure()
+
+    plt.show()
+
+
+def _getHeatmapData():
+    # Generate test data for heatmap
+
+    x = [f'Col {i}' for i in range(6)]
+    y = [f'Row {i}' for i in range(4)]
+    r = np.random.RandomState(25)
+    data = r.random_sample([len(y), len(x)])
+
+    return x, y, data
+
+
+if __name__ == '__main__':
+    main()

--- a/src/emcpy/plots/_norms.py
+++ b/src/emcpy/plots/_norms.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Iterable, Optional, Sequence
 import numpy as np
-from matplotlib.colors import Normalize, BoundaryNorm
+from matplotlib.colors import Normalize, BoundaryNorm, TwoSlopeNorm
 
 
 def compute_norm(
@@ -11,33 +11,31 @@ def compute_norm(
     levels: Sequence[float] | None = None,
     ncolors: int | None = None,
     clip: bool = False,
+    center: float | None = None,
 ):
     """
-    Choose a Matplotlib norm for a plot, with robust handling of integer categories.
+    Choose a Matplotlib norm for a plot, with robust handling of integer categories
+    and diverging (centered) continuous data.
 
-    - If integer_field is True:
-        - If `levels` given, use those as bin boundaries (must be monotonic and >= 2 long)
-        - Else require both vmin & vmax and build integer bin edges: [floor(vmin), ..., ceil(vmax)+1]
-        - Returns BoundaryNorm(boundaries, ncolors or 256, clip=False)
-    - Else:
-        - If vmin/vmax both None -> Normalize() (auto)
-        - If exactly one is None -> Normalize() (auto)
-        - If vmin == vmax -> ValueError
-        - Else -> Normalize(vmin, vmax)
+    - If integer_field is True: unchanged from before (BoundaryNorm path). `center`
+      is ignored for integer/categorical fields — it has no meaning there.
+    - Else, if `center` is given: build a TwoSlopeNorm around it. Requires vmin/vmax
+      (caller is expected to have inferred these from data already if not user-set).
+      If the data doesn't actually straddle `center`, the bound on the non-spanning
+      side is nudged just past `center` so TwoSlopeNorm doesn't raise.
+    - Else: original continuous behavior (Normalize / BoundaryNorm from levels).
     """
-    # Integer categories → discrete bins with half-step edges
+    # Integer categories → discrete bins with half-step edges (unchanged)
     if integer_field:
         if levels is not None:
             b = np.asarray(levels, dtype=float)
             if b.ndim != 1 or b.size < 2:
                 return None
-            # If the levels look like integer class centers, convert to edges
             if np.allclose(b, np.round(b)):
                 lo = int(np.floor(b.min()))
                 hi = int(np.ceil(b.max()))
                 boundaries = np.arange(lo - 0.5, hi + 1.5, 1.0)
             else:
-                # Already explicit edges; trust the caller
                 boundaries = b
             return BoundaryNorm(boundaries, ncolors or 256, clip=clip)
 
@@ -48,7 +46,24 @@ def compute_norm(
         boundaries = np.arange(lo - 0.5, hi + 1.5, 1.0)
         return BoundaryNorm(boundaries, ncolors or 256, clip=clip)
 
-    # Continuous case
+    # Diverging / centered continuous data
+    if center is not None:
+        if vmin is None or vmax is None:
+            raise ValueError("center=<value> requires both `vmin` and `vmax` "
+                             "(infer them from data upstream if not user-set).")
+        if vmin == vmax:
+            raise ValueError("vmin and vmax must differ when using a centered norm.")
+
+        span = max(abs(vmax - vmin), 1e-9)
+        eps = span * 0.01
+        if vmin >= center:
+            vmin = center - eps
+        if vmax <= center:
+            vmax = center + eps
+
+        return TwoSlopeNorm(vcenter=center, vmin=vmin, vmax=vmax)
+
+    # Continuous case (unchanged)
     if levels is not None:
         b = np.asarray(levels, dtype=float)
         if b.ndim == 1 and b.size >= 2:

--- a/src/emcpy/plots/adapters.py
+++ b/src/emcpy/plots/adapters.py
@@ -363,6 +363,33 @@ class Hist2DAdapter:
         return fig._hist2d(layer, st.ax)  # returns QuadMesh (ScalarMappable)
 
 
+@register
+class HeatMapAdapter:
+    plottype = "heatmap"
+
+    def render(self, fig, st: AxState, layer):
+        x = np.asarray(layer.x)
+        y = np.asarray(layer.y)
+        data = np.asarray(layer.data)
+
+        if x.ndim != 1 or y.ndim != 1:
+            raise ValueError(
+                f"HeatMap: x and y must be 1-D category labels; "
+                f"got x.ndim={x.ndim}, y.ndim={y.ndim}."
+            )
+        if data.ndim != 2:
+            raise ValueError(f"HeatMap: data must be 2-D; got {data.ndim}D.")
+        if data.shape != (len(y), len(x)):
+            raise ValueError(
+                "HeatMap: data.shape must be (len(y), len(x)); "
+                f"got data.shape={data.shape}, len(y)={len(y)}, len(x)={len(x)}."
+            )
+        if layer.center is not None and layer.integer_field:
+            raise ValueError("HeatMap: 'center' is not meaningful with integer_field=True.")
+
+        return fig._heatmap(layer, st.ax)  # returns QuadMesh (ScalarMappable)
+
+
 # Map variants
 @register
 class MapScatterAdapter:

--- a/src/emcpy/plots/create_plots.py
+++ b/src/emcpy/plots/create_plots.py
@@ -1274,6 +1274,64 @@ class CreateFigure:
 
         return img  # QuadMesh (ScalarMappable)
 
+    def _heatmap(self, plotobj, ax):
+        """
+        Render HeatMap layer: categorical pcolormesh with optional diverging norm,
+        NaN masking, and per-cell value annotations with auto text contrast.
+        """
+        skip = [
+            'plottype', 'x', 'y', 'data', 'colorbar', 'colorbar_label',
+            'annotate', 'annotate_fmt', 'annotate_fontsize', 'annotate_color',
+            'mask_color', 'center', 'integer_field',
+        ]
+        inputs = self._get_inputs_dict(skip, plotobj)
+        inputs.setdefault('shading', 'flat')
+
+        Z = np.ma.masked_invalid(np.asarray(plotobj.data, dtype=float))
+        nrows, ncols = Z.shape
+
+        self._apply_norm_from_layer(inputs, plotobj)
+
+        cmap_obj = _cmaps.get_cmap(inputs.get('cmap', 'viridis'))
+        cmap_obj = cmap_obj.copy()
+        cmap_obj.set_bad(plotobj.mask_color)
+        inputs['cmap'] = cmap_obj
+
+        # Cell edges so categories land on a clean grid
+        X = np.arange(ncols + 1) - 0.5
+        Y = np.arange(nrows + 1) - 0.5
+
+        qm = ax.pcolormesh(X, Y, Z, **inputs)
+
+        ax.set_xticks(np.arange(ncols))
+        ax.set_xticklabels(list(plotobj.x), rotation=45, ha='right')
+        ax.set_yticks(np.arange(nrows))
+        ax.set_yticklabels(list(plotobj.y))
+        ax.set_xlim(-0.5, ncols - 0.5)
+        ax.set_ylim(-0.5, nrows - 0.5)
+
+        if getattr(plotobj, 'annotate', True):
+            fmt = plotobj.annotate_fmt
+            fixed_color = plotobj.annotate_color
+            for i in range(nrows):
+                for j in range(ncols):
+                    if np.ma.is_masked(Z[i, j]) or not np.isfinite(Z[i, j]):
+                        continue
+                    val = float(Z[i, j])
+                    if fixed_color is not None:
+                        txt_color = fixed_color
+                    else:
+                        r, g, b, _ = qm.cmap(qm.norm(val))
+                        luminance = 0.299 * r + 0.587 * g + 0.114 * b
+                        txt_color = 'black' if luminance > 0.55 else 'white'
+                    ax.text(
+                        j, i, fmt.format(val),
+                        ha='center', va='center',
+                        color=txt_color, fontsize=plotobj.annotate_fontsize,
+                    )
+
+        return qm  # QuadMesh (ScalarMappable)
+
     def _supports_kw(self, func, name: str) -> bool:
         try:
             return name in inspect.signature(func).parameters
@@ -1349,60 +1407,57 @@ class CreateFigure:
         return None
 
     def _apply_norm_from_layer(self, inputs: dict[str, Any], layer: Any, *, keep_levels: bool = False) -> None:
-        """
-        Mutate `inputs` in-place to include a Matplotlib `norm` derived from the layer.
-
-        - Reads: layer.integer_field, layer.vmin, layer.vmax, layer.levels (if present)
-        - If integer_field and neither levels nor (vmin & vmax) are provided, infer
-          vmin/vmax from numeric data on the layer: c/data/z/C.
-        - If a norm is added, removes vmin/vmax from `inputs` to avoid double-specification.
-        - For contour/contourf, pass keep_levels=True to preserve 'levels' in `inputs`.
-        """
         if "norm" in inputs:
-            return  # caller already set a norm explicitly
+            return
 
         integer_field = bool(getattr(layer, "integer_field", False))
+        center = getattr(layer, "center", None)
         vmin = inputs.get("vmin", getattr(layer, "vmin", None))
         vmax = inputs.get("vmax", getattr(layer, "vmax", None))
         levels = inputs.get("levels", getattr(layer, "levels", None))
 
-        # If integer categories and nothing provided, try to infer from data
-        if integer_field and levels is None and (vmin is None or vmax is None):
-            # Candidate data arrays in priority order
+        def _infer_bounds_from_data():
             candidates = [
-                inputs.get("c", None),           # if caller passed through
-                getattr(layer, "c", None),       # scatter-style
-                getattr(layer, "data", None),    # map_scatter / map_gridded
-                getattr(layer, "z", None),       # gridded
-                getattr(layer, "C", None),       # hexbin w/ C
+                inputs.get("c", None),
+                getattr(layer, "c", None),
+                getattr(layer, "data", None),
+                getattr(layer, "z", None),
+                getattr(layer, "C", None),
             ]
-            arr = None
             for cand in candidates:
-                if cand is not None:
-                    try:
-                        arr = np.asarray(cand)
-                        break
-                    except Exception:
-                        arr = None
-            if arr is not None:
+                if cand is None:
+                    continue
+                try:
+                    arr = np.asarray(cand, dtype=float)
+                except Exception:
+                    continue
                 with np.errstate(invalid="ignore"):
                     arr = arr[np.isfinite(arr)]
                 if arr.size:
-                    vmin = float(np.floor(arr.min()))
-                    vmax = float(np.ceil(arr.max()))
+                    return float(arr.min()), float(arr.max())
+            return None, None
 
-        # If we inferred an integer range that collapses to a single value,
-        # widen it by 1 so we get at least one bin (three boundaries).
+        if integer_field and levels is None and (vmin is None or vmax is None):
+            inferred_min, inferred_max = _infer_bounds_from_data()
+            vmin = vmin if vmin is not None else inferred_min
+            vmax = vmax if vmax is not None else inferred_max
+
         if integer_field and levels is None and (vmin is not None) and (vmax is not None):
             if np.isclose(vmin, vmax):
                 vmax = vmin + 1.0
 
-        # Let the centralized policy build the norm (raises if still insufficient)
+        # Diverging/centered continuous data: infer missing bounds from data too
+        if (not integer_field) and center is not None and (vmin is None or vmax is None):
+            inferred_min, inferred_max = _infer_bounds_from_data()
+            vmin = vmin if vmin is not None else inferred_min
+            vmax = vmax if vmax is not None else inferred_max
+
         norm = compute_norm(
             integer_field=integer_field,
             vmin=vmin,
             vmax=vmax,
             levels=levels,
+            center=center,
         )
         if norm is not None:
             inputs["norm"] = norm

--- a/src/emcpy/plots/plots.py
+++ b/src/emcpy/plots/plots.py
@@ -11,7 +11,7 @@ __all__ = [
     'BarPlot', 'HorizontalBar', 'SkewT',
     'GriddedPlot', 'ContourPlot', 'FilledContourPlot',
     'BoxandWhiskerPlot', 'FillBetween', 'ErrorBar',
-    'ViolinPlot', 'HexBin', 'Hist2D',
+    'ViolinPlot', 'HexBin', 'Hist2D', 'HeatMap',
 ]
 
 
@@ -570,3 +570,45 @@ class Hist2D:
         self.colorbar = True
         self.colorbar_label = None
         self.colorbar_location = 'right'
+
+
+class HeatMap:
+    def __init__(self, x, y, data):
+        """
+        Categorical heatmap layer (e.g. variable x cycle matrix of a stat).
+
+        Args:
+            x: sequence of category labels for columns (e.g. cycle strings)
+            y: sequence of category labels for rows (e.g. variable names)
+            data: 2D array-like, shape (len(y), len(x))
+        """
+        super().__init__()
+        self.plottype = 'heatmap'
+
+        self.x = x
+        self.y = y
+        self.data = data
+
+        self.cmap = 'viridis'
+        self.vmin = None
+        self.vmax = None
+        self.center = None  # e.g. 0.0 for bias-type stats -> diverging norm
+        self.integer_field = False  # inherited knob; usually False for heatmaps
+
+        self.edgecolors = 'white'
+        self.linewidths = 0.5
+        self.alpha = None
+        self.zorder = None
+        self.label = None
+
+        # Cell annotation
+        self.annotate = True
+        self.annotate_fmt = '{:.2f}'
+        self.annotate_fontsize = 8
+        self.annotate_color = None  # None -> auto contrast per cell; else fixed color
+
+        # Missing-data handling
+        self.mask_color = 'lightgray'
+
+        self.colorbar = True
+        self.colorbar_label = None

--- a/src/tests/plotting/test_heatmaps.py
+++ b/src/tests/plotting/test_heatmaps.py
@@ -1,0 +1,97 @@
+import numpy as np
+import pytest
+from matplotlib.colors import TwoSlopeNorm
+
+from emcpy.plots.plots import HeatMap
+from emcpy.plots.create_plots import CreatePlot, CreateFigure
+from emcpy.plots._norms import compute_norm
+
+
+def _heatmap_data():
+    x = ["08/09 00Z", "08/09 06Z", "08/09 12Z", "08/09 18Z"]
+    y = ["TEMP", "UWND", "VWND"]
+    data = np.array([
+        [0.12, -0.34, 0.05, np.nan],
+        [-1.2, -0.9, -1.1, -1.0],
+        [0.8, 0.75, np.nan, 0.6],
+    ])
+    return x, y, data
+
+
+def test_heatmap_basic_renders(single_axes):
+    x, y, data = _heatmap_data()
+    plot = CreatePlot(plot_layers=[HeatMap(x, y, data)])
+    fig, ax = single_axes(plot)
+    assert fig._last_mappable_for_ax(ax) is not None
+    assert [t.get_text() for t in ax.get_xticklabels()] == x
+    assert [t.get_text() for t in ax.get_yticklabels()] == y
+
+
+def test_heatmap_masks_nan_and_skips_annotation(single_axes):
+    x, y, data = _heatmap_data()
+    plot = CreatePlot(plot_layers=[HeatMap(x, y, data)])
+    fig, ax = single_axes(plot)
+    n_finite = np.isfinite(data).sum()
+    assert len(ax.texts) == n_finite
+
+
+def test_heatmap_annotate_false_adds_no_text(single_axes):
+    x, y, data = _heatmap_data()
+    layer = HeatMap(x, y, data)
+    layer.annotate = False
+    plot = CreatePlot(plot_layers=[layer])
+    _, ax = single_axes(plot)
+    assert len(ax.texts) == 0
+
+
+def test_heatmap_center_uses_diverging_norm(single_axes):
+    x, y, data = _heatmap_data()
+    layer = HeatMap(x, y, data)
+    layer.center = 0.0
+    plot = CreatePlot(plot_layers=[layer])
+    fig, ax = single_axes(plot)
+    qm = fig._last_mappable_for_ax(ax)
+    assert isinstance(qm.norm, TwoSlopeNorm)
+    assert qm.norm.vcenter == 0.0
+
+
+def test_heatmap_center_ignored_when_data_all_one_side(single_axes):
+    # All-positive data with center=0.0 shouldn't raise; bound gets nudged.
+    x, y = ["a", "b"], ["r1"]
+    data = np.array([[1.0, 2.0]])
+    layer = HeatMap(x, y, data)
+    layer.center = 0.0
+    plot = CreatePlot(plot_layers=[layer])
+    fig, ax = single_axes(plot)
+    qm = fig._last_mappable_for_ax(ax)
+    assert isinstance(qm.norm, TwoSlopeNorm)
+    assert qm.norm.vmin < 0.0 < qm.norm.vmax
+
+
+def test_heatmap_shape_mismatch_raises(single_axes):
+    x, y = ["a", "b", "c"], ["r1", "r2"]
+    data = np.zeros((3, 3))  # wrong: should be (2, 3)
+    plot = CreatePlot(plot_layers=[HeatMap(x, y, data)])
+    with pytest.raises(ValueError, match="data.shape must be"):
+        single_axes(plot)
+
+
+def test_heatmap_center_with_integer_field_raises(single_axes):
+    x, y = ["a", "b"], ["r1"]
+    layer = HeatMap(x, y, np.array([[1.0, 2.0]]))
+    layer.center = 0.0
+    layer.integer_field = True
+    plot = CreatePlot(plot_layers=[layer])
+    with pytest.raises(ValueError, match="not meaningful"):
+        single_axes(plot)
+
+
+def test_compute_norm_center_basic():
+    norm = compute_norm(integer_field=False, vmin=-2.0, vmax=3.0, center=0.0)
+    assert isinstance(norm, TwoSlopeNorm)
+    assert norm.vmin == -2.0 and norm.vmax == 3.0 and norm.vcenter == 0.0
+
+
+def test_compute_norm_center_requires_bounds():
+    with pytest.raises(ValueError, match="requires both"):
+        compute_norm(integer_field=False, vmin=None, vmax=None, center=0.0)


### PR DESCRIPTION
## Add HeatMap layer type for categorical variable/cycle matrices

### Rationale
This PR adds `HeatMap` as a new EMCPy layer type. `GriddedPlot` was considered as a reuse path (it already wraps
`pcolormesh` with norm/colorbar handling), but categorical axis labels, cell-value annotations, and centered/diverging normalization don't fit its numeric-coordinate contract without overloading it. A dedicated layer keeps `GriddedPlot`'s continuous-coordinate use cases unchanged and gives the heatmap case an explicit, self-documenting API.

### Changes

- **`emcpy/plots/plots.py`**
  - New `HeatMap` layer class (`plottype = 'heatmap'`): categorical
    `x`/`y` labels, 2D `data`, `cmap`/`vmin`/`vmax`/`center` for norm
    control, `annotate`/`annotate_fmt`/`annotate_fontsize`/
    `annotate_color` for cell-value text, `mask_color` for NaN cells.
  - Added `'HeatMap'` to `__all__`.

- **`emcpy/plots/_norms.py`**
  - Extended `compute_norm()` with a `center` kwarg. When set on
    non-integer-field data, builds a `TwoSlopeNorm(vcenter=center, ...)`
    instead of a plain `Normalize`. If the data doesn't actually
    straddle `center` (e.g. all-positive values with `center=0`), the
    non-spanning bound is nudged just past `center` (±1% of span) so
    `TwoSlopeNorm` doesn't raise. Existing `integer_field`/`BoundaryNorm`
    and plain-`Normalize` paths are untouched — `center` is a pure
    addition, not a refactor of existing behavior.

- **`emcpy/plots/create_plots.py`**
  - `_apply_norm_from_layer`: now reads `layer.center` and infers
    `vmin`/`vmax` from layer data the same way it already does for
    `integer_field`, when bounds aren't explicitly set.
  - New `_heatmap()` render method: builds a categorical `pcolormesh`
    grid from integer cell edges, masks NaN/missing cells via
    `np.ma.masked_invalid` + `cmap.set_bad(mask_color)`, sets tick
    labels directly from `layer.x`/`layer.y`, and (when
    `annotate=True`) overlays per-cell text with automatic black/white
    contrast based on the rendered cell color's perceived luminance.
    Returns the `QuadMesh` so existing colorbar/extend/integer-tick
    machinery (`_last_mappable_for_ax`, `_auto_extend_for_colorbar`,
    etc.) picks it up with no changes needed there.

- **`emcpy/plots/adapters.py`**
  - New `HeatMapAdapter` (`plottype = 'heatmap'`), registered via
    `@register`. Validates `x`/`y` are 1D, `data` is 2D and matches
    `(len(y), len(x))`, and rejects `center` combined with
    `integer_field=True` (not a meaningful combination) before
    delegating to `fig._heatmap()`.

- **`src/tests/plotting/test_heatmap.py`** (new)
  - Basic render + tick-label correctness
  - NaN masking and matching annotation-count behavior
  - `annotate=False` produces no text artists
  - `center` produces `TwoSlopeNorm` with correct `vcenter`
  - All-positive data + `center=0` nudges bounds rather than raising
  - Shape-mismatch and `center` + `integer_field` combination both
    raise clear `ValueError`s
  - `compute_norm` unit tests for the new `center` path directly

- **`galleries/plot_types/gridded/heatmap.py`** (new)
  - Minimal "how to use `HeatMap`" gallery entry, matching the
    existing `gridded.py` structure/style.

- **`galleries/examples/gridded_plots/heatmap_basic.py`** (new)
  - Fuller example using `center=0.0`, annotations, and injected NaNs
    to demonstrate the diverging-colormap + missing-data case this
    layer was built for, matching `pcolormesh_basic.py`'s style.

### Example HeatMap

<img width="1462" height="802" alt="image" src="https://github.com/user-attachments/assets/be2395ab-4412-44bc-8323-6f0d2005bba9" />

